### PR TITLE
User book index

### DIFF
--- a/app/controllers/user/books_controller.rb
+++ b/app/controllers/user/books_controller.rb
@@ -1,0 +1,5 @@
+class User::BooksController < ApplicationController
+  def index
+    @userbooks = UserBook.where(user_id: current_user.id)
+  end
+end

--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -1,0 +1,5 @@
+class UserBook < ApplicationRecord
+  belongs_to :user
+
+  validates_presence_of :status, :user_id, :isbn
+end

--- a/app/models/user_book.rb
+++ b/app/models/user_book.rb
@@ -2,4 +2,12 @@ class UserBook < ApplicationRecord
   belongs_to :user
 
   validates_presence_of :status, :user_id, :isbn
+
+  def self.find_available_books
+    where(status: 'available')
+  end
+
+  def self.find_unavailable_books
+    where.not(status: 'available')
+  end
 end

--- a/app/poros/book.rb
+++ b/app/poros/book.rb
@@ -1,6 +1,6 @@
 class Book
 
-  attr_reader :title, :author, :description, :thumbnail, :isbn
+  attr_reader :title, :author, :description, :thumbnail, :isbn, :category
 
   def initialize(attributes)
     @title = attributes[:items].first[:volumeInfo][:title]
@@ -10,5 +10,6 @@ class Book
     @isbn = attributes[:items].first[:volumeInfo][:industryIdentifiers].find do |e|
       e[:type] == "ISBN_13"
     end[:identifier]
+    @category = attributes[:items].first[:volumeInfo][:categories].first
   end
 end

--- a/app/poros/book.rb
+++ b/app/poros/book.rb
@@ -12,8 +12,4 @@ class Book
     end[:identifier]
     @category = attributes[:items].first[:volumeInfo][:categories].first
   end
-
-  def self.find_by_isbn(isbn)
-
-  end
 end

--- a/app/poros/book.rb
+++ b/app/poros/book.rb
@@ -12,4 +12,8 @@ class Book
     end[:identifier]
     @category = attributes[:items].first[:volumeInfo][:categories].first
   end
+
+  def self.find_by_isbn(isbn)
+
+  end
 end

--- a/app/poros/book.rb
+++ b/app/poros/book.rb
@@ -1,0 +1,14 @@
+class Book
+
+  attr_reader :title, :author, :description, :thumbnail, :isbn
+
+  def initialize(attributes)
+    @title = attributes[:items].first[:volumeInfo][:title]
+    @author = attributes[:items].first[:volumeInfo][:authors].first
+    @description = attributes[:items].first[:volumeInfo][:description]
+    @thumbnail = attributes[:items].first[:volumeInfo][:imageLinks][:thumbnail]
+    @isbn = attributes[:items].first[:volumeInfo][:industryIdentifiers].find do |e|
+      e[:type] == "ISBN_13"
+    end[:identifier]
+  end
+end

--- a/app/views/user/books/index.html.erb
+++ b/app/views/user/books/index.html.erb
@@ -1,0 +1,15 @@
+<h3><%= current_user.first_name %>'s Book Shelf</h3>
+
+<% if @userbooks.find_unavailable_books.present?  %>
+  <p>Off The Shelf</p>
+  <% @userbooks.find_unavailable_books.each do |book| %>
+    <%= book.isbn %>
+  <% end %>
+<% end %>
+
+<% if @userbooks.find_available_books.present?  %>
+  <p>On The Shelf</p>
+  <% @userbooks.find_available_books.each do |book| %>
+    <%= book.isbn %>
+  <% end %>
+<% end %>

--- a/db/migrate/20200913030938_create_user_books.rb
+++ b/db/migrate/20200913030938_create_user_books.rb
@@ -1,0 +1,8 @@
+class CreateUserBooks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_books do |t|
+      t.string :status
+      t.string :isbn
+    end
+  end
+end

--- a/db/migrate/20200913031122_add_user_to_user_book.rb
+++ b/db/migrate/20200913031122_add_user_to_user_book.rb
@@ -1,0 +1,5 @@
+class AddUserToUserBook < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :user_books, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2020_09_12_211631) do
+ActiveRecord::Schema.define(version: 2020_09_13_031122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +25,8 @@ ActiveRecord::Schema.define(version: 2020_09_12_211631) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
   create_table "friendships", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "friend_id"
@@ -33,6 +34,13 @@ ActiveRecord::Schema.define(version: 2020_09_12_211631) do
     t.datetime "updated_at", null: false
     t.index ["friend_id"], name: "index_friendships_on_friend_id"
     t.index ["user_id"], name: "index_friendships_on_user_id"
+  end
+
+  create_table "user_books", force: :cascade do |t|
+    t.string "status"
+    t.string "isbn"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_user_books_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -50,4 +58,5 @@ ActiveRecord::Schema.define(version: 2020_09_12_211631) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "friendships", "users"
+  add_foreign_key "user_books", "users"
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -86,21 +86,107 @@ RSpec.describe 'User Book Index Page' do
     }
     json_call = api_call.to_json
     book_attrs = JSON.parse(json_call, symbolize_names: true)
-    @book = Book.new(book_attrs)
+    @book1 = Book.new(book_attrs)
+
+    api_call2 = {
+    "kind": "books#volumes",
+    "totalItems": 1,
+    "items": [
+      {
+        "kind": "books#volume",
+        "id": "WEW1cC7yaCQC",
+        "etag": "LN8exKcLrq4",
+        "selfLink": "https://www.googleapis.com/books/v1/volumes/WEW1cC7yaCQC",
+        "volumeInfo": {
+          "title": "Test Book",
+          "authors": [
+            "Test Author"
+          ],
+          "publisher": "St. Martin's Press",
+          "publishedDate": "2013-10",
+          "description": "Book description test",
+          "industryIdentifiers": [
+            {
+              "type": "ISBN_10",
+              "identifier": "076537062X"
+            },
+            {
+              "type": "ISBN_13",
+              "identifier": "1234567890123"
+            }
+          ],
+          "readingModes": {
+            "text": false,
+            "image": false
+          },
+          "pageCount": 324,
+          "printType": "BOOK",
+          "categories": [
+            "Fiction"
+          ],
+          "averageRating": 4,
+          "ratingsCount": 679,
+          "maturityRating": "NOT_MATURE",
+          "allowAnonLogging": false,
+          "contentVersion": "0.8.3.0.preview.0",
+          "panelizationSummary": {
+            "containsEpubBubbles": false,
+            "containsImageBubbles": false
+          },
+          "imageLinks": {
+            "smallThumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+            "thumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+          },
+          "language": "en",
+          "previewLink": "http://books.google.com/books?id=WEW1cC7yaCQC&printsec=frontcover&dq=isbn:9780765370624&hl=&cd=1&source=gbs_api",
+          "infoLink": "http://books.google.com/books?id=WEW1cC7yaCQC&dq=isbn:9780765370624&hl=&source=gbs_api",
+          "canonicalVolumeLink": "https://books.google.com/books/about/Ender_s_Game.html?hl=&id=WEW1cC7yaCQC"
+        },
+        "saleInfo": {
+          "country": "US",
+          "saleability": "NOT_FOR_SALE",
+          "isEbook": false
+        },
+        "accessInfo": {
+          "country": "US",
+          "viewability": "PARTIAL",
+          "embeddable": true,
+          "publicDomain": false,
+          "textToSpeechPermission": "ALLOWED",
+          "epub": {
+            "isAvailable": false
+          },
+          "pdf": {
+            "isAvailable": false
+          },
+          "webReaderLink": "http://play.google.com/books/reader?id=WEW1cC7yaCQC&hl=&printsec=frontcover&source=gbs_api",
+          "accessViewStatus": "SAMPLE",
+          "quoteSharingAllowed": false
+        },
+        "searchInfo": {
+          "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+        }
+      }
+    ]
+    }
+    json_call2 = api_call2.to_json
+    book_attrs2 = JSON.parse(json_call2, symbolize_names: true)
+    @book2 = Book.new(book_attrs2)
   end
 
   it 'My books show up on the shelf' do
     UserBook.create({
       user_id: current_user.id,
-      isbn: @book.isbn,
+      isbn: @book1.isbn,
       status: 'available'
       })
     UserBook.create({
       user_id: current_user.id,
-      isbn: "123456789",
+      isbn: @book2.isbn,
       status: 'unavailable'
       })
     visit 'user/books'
-    expect(page).to have_content(@book.isbn)
+    expect(page).to have_content(@book1.isbn)
+    expect(page).to have_content(@book2.isbn)
   end
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe 'User Book Index Page' do
+  before :each do
+    login_as_user
+    
+  end
+end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -3,6 +3,99 @@ require 'rails_helper'
 RSpec.describe 'User Book Index Page' do
   before :each do
     login_as_user
-    
+    api_call = {
+    "kind": "books#volumes",
+    "totalItems": 1,
+    "items": [
+      {
+        "kind": "books#volume",
+        "id": "WEW1cC7yaCQC",
+        "etag": "LN8exKcLrq4",
+        "selfLink": "https://www.googleapis.com/books/v1/volumes/WEW1cC7yaCQC",
+        "volumeInfo": {
+          "title": "Ender's Game",
+          "authors": [
+            "Orson Scott Card"
+          ],
+          "publisher": "St. Martin's Press",
+          "publishedDate": "2013-10",
+          "description": "An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.",
+          "industryIdentifiers": [
+            {
+              "type": "ISBN_10",
+              "identifier": "076537062X"
+            },
+            {
+              "type": "ISBN_13",
+              "identifier": "9780765370624"
+            }
+          ],
+          "readingModes": {
+            "text": false,
+            "image": false
+          },
+          "pageCount": 324,
+          "printType": "BOOK",
+          "categories": [
+            "Fiction"
+          ],
+          "averageRating": 4,
+          "ratingsCount": 679,
+          "maturityRating": "NOT_MATURE",
+          "allowAnonLogging": false,
+          "contentVersion": "0.8.3.0.preview.0",
+          "panelizationSummary": {
+            "containsEpubBubbles": false,
+            "containsImageBubbles": false
+          },
+          "imageLinks": {
+            "smallThumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+            "thumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+          },
+          "language": "en",
+          "previewLink": "http://books.google.com/books?id=WEW1cC7yaCQC&printsec=frontcover&dq=isbn:9780765370624&hl=&cd=1&source=gbs_api",
+          "infoLink": "http://books.google.com/books?id=WEW1cC7yaCQC&dq=isbn:9780765370624&hl=&source=gbs_api",
+          "canonicalVolumeLink": "https://books.google.com/books/about/Ender_s_Game.html?hl=&id=WEW1cC7yaCQC"
+        },
+        "saleInfo": {
+          "country": "US",
+          "saleability": "NOT_FOR_SALE",
+          "isEbook": false
+        },
+        "accessInfo": {
+          "country": "US",
+          "viewability": "PARTIAL",
+          "embeddable": true,
+          "publicDomain": false,
+          "textToSpeechPermission": "ALLOWED",
+          "epub": {
+            "isAvailable": false
+          },
+          "pdf": {
+            "isAvailable": false
+          },
+          "webReaderLink": "http://play.google.com/books/reader?id=WEW1cC7yaCQC&hl=&printsec=frontcover&source=gbs_api",
+          "accessViewStatus": "SAMPLE",
+          "quoteSharingAllowed": false
+        },
+        "searchInfo": {
+          "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+        }
+      }
+    ]
+    }
+    json_call = api_call.to_json
+    book_attrs = JSON.parse(json_call, symbolize_names: true)
+    @book = Book.new(book_attrs)
+  end
+
+  it 'My books show up on the shelf' do
+    UserBook.create({
+      user_id: current_user.id,
+      isbn: @book.isbn,
+      status: 'available'
+      })
+    visit 'user/books'
+    expect(page).to have_content(@book.isbn)
   end
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe 'User Book Index Page' do
       isbn: @book.isbn,
       status: 'available'
       })
+    UserBook.create({
+      user_id: current_user.id,
+      isbn: "123456789",
+      status: 'unavailable'
+      })
     visit 'user/books'
     expect(page).to have_content(@book.isbn)
   end

--- a/spec/models/user_book_spec.rb
+++ b/spec/models/user_book_spec.rb
@@ -10,4 +10,28 @@ RSpec.describe UserBook, type: :model do
   describe 'relationships' do
     it { should belong_to :user}
   end
+
+  describe 'class methods' do
+    before :each do
+    @user = User.create(id: 1)
+    @ub1 = UserBook.create({
+      user_id: @user.id,
+      isbn: "123456789",
+      status: "available"
+      })
+    @ub2 = UserBook.create({
+      user_id: @user.id,
+      isbn: "987654321",
+      status: "unavailable"
+      })
+    end
+
+    it "find_available_books" do
+      expect(UserBook.find_available_books).to eq([@ub1])
+    end
+
+    it "find_unavailable_books" do
+      expect(UserBook.find_unavailable_books).to eq([@ub2])
+    end
+  end
 end

--- a/spec/models/user_book_spec.rb
+++ b/spec/models/user_book_spec.rb
@@ -174,7 +174,8 @@ RSpec.describe UserBook, type: :model do
             "quoteSharingAllowed": false
           },
           "searchInfo": {
-            "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+            "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the la
+            st Earth fleet against an alien race seeking Earth&#39;s complete destruction."
           }
         }
       ]

--- a/spec/models/user_book_spec.rb
+++ b/spec/models/user_book_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe UserBook, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :status }
+    it { should validate_presence_of :user_id }
+    it { should validate_presence_of :isbn }
+  end
+
+  describe 'relationships' do
+    it { should belong_to :user}
+  end
+end

--- a/spec/models/user_book_spec.rb
+++ b/spec/models/user_book_spec.rb
@@ -13,17 +13,186 @@ RSpec.describe UserBook, type: :model do
 
   describe 'class methods' do
     before :each do
-    @user = User.create(id: 1)
-    @ub1 = UserBook.create({
-      user_id: @user.id,
-      isbn: "123456789",
-      status: "available"
-      })
-    @ub2 = UserBook.create({
-      user_id: @user.id,
-      isbn: "987654321",
-      status: "unavailable"
-      })
+      api_call = {
+      "kind": "books#volumes",
+      "totalItems": 1,
+      "items": [
+        {
+          "kind": "books#volume",
+          "id": "WEW1cC7yaCQC",
+          "etag": "LN8exKcLrq4",
+          "selfLink": "https://www.googleapis.com/books/v1/volumes/WEW1cC7yaCQC",
+          "volumeInfo": {
+            "title": "Ender's Game",
+            "authors": [
+              "Orson Scott Card"
+            ],
+            "publisher": "St. Martin's Press",
+            "publishedDate": "2013-10",
+            "description": "An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.",
+            "industryIdentifiers": [
+              {
+                "type": "ISBN_10",
+                "identifier": "076537062X"
+              },
+              {
+                "type": "ISBN_13",
+                "identifier": "9780765370624"
+              }
+            ],
+            "readingModes": {
+              "text": false,
+              "image": false
+            },
+            "pageCount": 324,
+            "printType": "BOOK",
+            "categories": [
+              "Fiction"
+            ],
+            "averageRating": 4,
+            "ratingsCount": 679,
+            "maturityRating": "NOT_MATURE",
+            "allowAnonLogging": false,
+            "contentVersion": "0.8.3.0.preview.0",
+            "panelizationSummary": {
+              "containsEpubBubbles": false,
+              "containsImageBubbles": false
+            },
+            "imageLinks": {
+              "smallThumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+              "thumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+            },
+            "language": "en",
+            "previewLink": "http://books.google.com/books?id=WEW1cC7yaCQC&printsec=frontcover&dq=isbn:9780765370624&hl=&cd=1&source=gbs_api",
+            "infoLink": "http://books.google.com/books?id=WEW1cC7yaCQC&dq=isbn:9780765370624&hl=&source=gbs_api",
+            "canonicalVolumeLink": "https://books.google.com/books/about/Ender_s_Game.html?hl=&id=WEW1cC7yaCQC"
+          },
+          "saleInfo": {
+            "country": "US",
+            "saleability": "NOT_FOR_SALE",
+            "isEbook": false
+          },
+          "accessInfo": {
+            "country": "US",
+            "viewability": "PARTIAL",
+            "embeddable": true,
+            "publicDomain": false,
+            "textToSpeechPermission": "ALLOWED",
+            "epub": {
+              "isAvailable": false
+            },
+            "pdf": {
+              "isAvailable": false
+            },
+            "webReaderLink": "http://play.google.com/books/reader?id=WEW1cC7yaCQC&hl=&printsec=frontcover&source=gbs_api",
+            "accessViewStatus": "SAMPLE",
+            "quoteSharingAllowed": false
+          },
+          "searchInfo": {
+            "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+          }
+        }
+      ]
+      }
+      json_call = api_call.to_json
+      book_attrs = JSON.parse(json_call, symbolize_names: true)
+      @book1 = Book.new(book_attrs)
+
+      api_call2 = {
+      "kind": "books#volumes",
+      "totalItems": 1,
+      "items": [
+        {
+          "kind": "books#volume",
+          "id": "WEW1cC7yaCQC",
+          "etag": "LN8exKcLrq4",
+          "selfLink": "https://www.googleapis.com/books/v1/volumes/WEW1cC7yaCQC",
+          "volumeInfo": {
+            "title": "Test Book",
+            "authors": [
+              "Test Author"
+            ],
+            "publisher": "St. Martin's Press",
+            "publishedDate": "2013-10",
+            "description": "Book description test",
+            "industryIdentifiers": [
+              {
+                "type": "ISBN_10",
+                "identifier": "076537062X"
+              },
+              {
+                "type": "ISBN_13",
+                "identifier": "1234567890123"
+              }
+            ],
+            "readingModes": {
+              "text": false,
+              "image": false
+            },
+            "pageCount": 324,
+            "printType": "BOOK",
+            "categories": [
+              "Fiction"
+            ],
+            "averageRating": 4,
+            "ratingsCount": 679,
+            "maturityRating": "NOT_MATURE",
+            "allowAnonLogging": false,
+            "contentVersion": "0.8.3.0.preview.0",
+            "panelizationSummary": {
+              "containsEpubBubbles": false,
+              "containsImageBubbles": false
+            },
+            "imageLinks": {
+              "smallThumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+              "thumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+            },
+            "language": "en",
+            "previewLink": "http://books.google.com/books?id=WEW1cC7yaCQC&printsec=frontcover&dq=isbn:9780765370624&hl=&cd=1&source=gbs_api",
+            "infoLink": "http://books.google.com/books?id=WEW1cC7yaCQC&dq=isbn:9780765370624&hl=&source=gbs_api",
+            "canonicalVolumeLink": "https://books.google.com/books/about/Ender_s_Game.html?hl=&id=WEW1cC7yaCQC"
+          },
+          "saleInfo": {
+            "country": "US",
+            "saleability": "NOT_FOR_SALE",
+            "isEbook": false
+          },
+          "accessInfo": {
+            "country": "US",
+            "viewability": "PARTIAL",
+            "embeddable": true,
+            "publicDomain": false,
+            "textToSpeechPermission": "ALLOWED",
+            "epub": {
+              "isAvailable": false
+            },
+            "pdf": {
+              "isAvailable": false
+            },
+            "webReaderLink": "http://play.google.com/books/reader?id=WEW1cC7yaCQC&hl=&printsec=frontcover&source=gbs_api",
+            "accessViewStatus": "SAMPLE",
+            "quoteSharingAllowed": false
+          },
+          "searchInfo": {
+            "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+          }
+        }
+      ]
+      }
+      json_call2 = api_call2.to_json
+      book_attrs2 = JSON.parse(json_call2, symbolize_names: true)
+      @book2 = Book.new(book_attrs2)
+      @user = User.create(id: 1)
+      @ub1 = UserBook.create({
+        user_id: @user.id,
+        isbn: @book1.isbn,
+        status: "available"
+        })
+      @ub2 = UserBook.create({
+        user_id: @user.id,
+        isbn: @book2.isbn,
+        status: "unavailable"
+        })
     end
 
     it "find_available_books" do

--- a/spec/poros/book_spec.rb
+++ b/spec/poros/book_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Book, type: :poro do
-  it 'an api call can create a book object' do
+  before :each do
     api_call = {
     "kind": "books#volumes",
     "totalItems": 1,
@@ -85,13 +85,15 @@ RSpec.describe Book, type: :poro do
   }
   json_call = api_call.to_json
   book_attrs = JSON.parse(json_call, symbolize_names: true)
-  book = Book.new(book_attrs)
-  expect(book.class).to eq(Book)
-  expect(book.title).to eq("Ender's Game")
-  expect(book.author).to eq("Orson Scott Card")
-  expect(book.description).to eq("An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.")
-  expect(book.thumbnail).to eq("http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api")
-  expect(book.isbn).to eq("9780765370624")
-  expect(book.category).to eq('Fiction')
+  @book = Book.new(book_attrs)
+end
+  it 'an api call can create a book object' do
+    expect(@book.class).to eq(Book)
+    expect(@book.title).to eq("Ender's Game")
+    expect(@book.author).to eq("Orson Scott Card")
+    expect(@book.description).to eq("An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.")
+    expect(@book.thumbnail).to eq("http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api")
+    expect(@book.isbn).to eq("9780765370624")
+    expect(@book.category).to eq('Fiction')
   end
 end

--- a/spec/poros/book_spec.rb
+++ b/spec/poros/book_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe Book, type: :poro do
   expect(book.description).to eq("An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.")
   expect(book.thumbnail).to eq("http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api")
   expect(book.isbn).to eq("9780765370624")
-
-
+  expect(book.category).to eq('Fiction')
   end
 end

--- a/spec/poros/book_spec.rb
+++ b/spec/poros/book_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe Book, type: :poro do
+  it 'an api call can create a book object' do
+    api_call = {
+    "kind": "books#volumes",
+    "totalItems": 1,
+    "items": [
+      {
+        "kind": "books#volume",
+        "id": "WEW1cC7yaCQC",
+        "etag": "LN8exKcLrq4",
+        "selfLink": "https://www.googleapis.com/books/v1/volumes/WEW1cC7yaCQC",
+        "volumeInfo": {
+          "title": "Ender's Game",
+          "authors": [
+            "Orson Scott Card"
+          ],
+          "publisher": "St. Martin's Press",
+          "publishedDate": "2013-10",
+          "description": "An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.",
+          "industryIdentifiers": [
+            {
+              "type": "ISBN_10",
+              "identifier": "076537062X"
+            },
+            {
+              "type": "ISBN_13",
+              "identifier": "9780765370624"
+            }
+          ],
+          "readingModes": {
+            "text": false,
+            "image": false
+          },
+          "pageCount": 324,
+          "printType": "BOOK",
+          "categories": [
+            "Fiction"
+          ],
+          "averageRating": 4,
+          "ratingsCount": 679,
+          "maturityRating": "NOT_MATURE",
+          "allowAnonLogging": false,
+          "contentVersion": "0.8.3.0.preview.0",
+          "panelizationSummary": {
+            "containsEpubBubbles": false,
+            "containsImageBubbles": false
+          },
+          "imageLinks": {
+            "smallThumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+            "thumbnail": "http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+          },
+          "language": "en",
+          "previewLink": "http://books.google.com/books?id=WEW1cC7yaCQC&printsec=frontcover&dq=isbn:9780765370624&hl=&cd=1&source=gbs_api",
+          "infoLink": "http://books.google.com/books?id=WEW1cC7yaCQC&dq=isbn:9780765370624&hl=&source=gbs_api",
+          "canonicalVolumeLink": "https://books.google.com/books/about/Ender_s_Game.html?hl=&id=WEW1cC7yaCQC"
+        },
+        "saleInfo": {
+          "country": "US",
+          "saleability": "NOT_FOR_SALE",
+          "isEbook": false
+        },
+        "accessInfo": {
+          "country": "US",
+          "viewability": "PARTIAL",
+          "embeddable": true,
+          "publicDomain": false,
+          "textToSpeechPermission": "ALLOWED",
+          "epub": {
+            "isAvailable": false
+          },
+          "pdf": {
+            "isAvailable": false
+          },
+          "webReaderLink": "http://play.google.com/books/reader?id=WEW1cC7yaCQC&hl=&printsec=frontcover&source=gbs_api",
+          "accessViewStatus": "SAMPLE",
+          "quoteSharingAllowed": false
+        },
+        "searchInfo": {
+          "textSnippet": "An expert at simulated war games, Andrew &quot;Ender&quot; Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth&#39;s complete destruction."
+        }
+      }
+    ]
+  }
+  json_call = api_call.to_json
+  book_attrs = JSON.parse(json_call, symbolize_names: true)
+  book = Book.new(book_attrs)
+  expect(book.class).to eq(Book)
+  expect(book.title).to eq("Ender's Game")
+  expect(book.author).to eq("Orson Scott Card")
+  expect(book.description).to eq("An expert at simulated war games, Andrew \"Ender\" Wiggin believes that he is engaged in one more computer war game when, in truth, he is commanding the last Earth fleet against an alien race seeking Earth's complete destruction.")
+  expect(book.thumbnail).to eq("http://books.google.com/books/content?id=WEW1cC7yaCQC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api")
+  expect(book.isbn).to eq("9780765370624")
+
+
+  end
+end


### PR DESCRIPTION
# Description

# Closes issue(s)
#22 (User Book Index  - Some Modifications still need to be made

# How to test / reproduce
 - RSpec feature test 
 - RSpec model tests, include AR query tests

# Screenshots
<img width="376" alt="Screen Shot 2020-09-13 at 12 15 34 AM" src="https://user-images.githubusercontent.com/62251085/93011771-7f4d8200-f556-11ea-9280-e6c56bada36a.png">

<img width="452" alt="Screen Shot 2020-09-13 at 12 13 14 AM" src="https://user-images.githubusercontent.com/62251085/93011788-a73ce580-f556-11ea-9752-37162d7d8532.png">

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have tested this code
- [ ] I have updated the Readme

# Other comments
Currently, the book index show page shows the ISBN from the UserBook model object. The goal is to have the book cover show. I wanted to get this PR in to get the UserBook model into the master. 
I've been going back and forth on this for awhile. I think, until we have a a way to make API calls, it doesn't make sense to send  books to the view page yet. 