### PR TITLE
Change Find Books to Browse Books

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
       <nav>
         <%= link_to "Home", root_path %>
         <%= link_to "Dashboard", user_dashboard_path %>
-        <%= link_to "Find Books", books_path %>
+        <%= link_to "Browse Books", books_path %>
         <%= link_to "Friends", user_friends_path %>
         <%= link_to "My Books", user_books_path %>
         <%= link_to "Account Info", user_account_path %>

--- a/spec/features/navigation/nav_bar_spec.rb
+++ b/spec/features/navigation/nav_bar_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Navigation Bar' do
     within 'nav' do
       expect(page).to have_link('Home', href: root_path)
       expect(page).to have_link('Dashboard', href: user_dashboard_path)
-      expect(page).to have_link('Find Books', href: books_path)
+      expect(page).to have_link('Browse Books', href: books_path)
       expect(page).to have_link('Friends', href: user_friends_path)
       expect(page).to have_link('My Books', href: user_books_path)
       expect(page).to have_link('Account Info', href: user_account_path)
@@ -25,7 +25,7 @@ RSpec.describe 'Navigation Bar' do
     visit root_path
     click_link 'Dashboard'
     expect(current_path).to eq(user_dashboard_path)
-    click_link 'Find Books'
+    click_link 'Browse Books'
     expect(current_path).to eq(books_path)
     click_link 'Friends'
     expect(current_path).to eq(user_friends_path)


### PR DESCRIPTION
# Description
Changes the name of nav bar link for the Books Index to 'Browse Books'

# Closes issue(s)

# How to test / reproduce

# Screenshots

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

# Other comments
