### PR TITLE
BIG CHANGES: Address workflow && UX improvements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -45,6 +45,10 @@ body {
   height: 300px;
 }
 
+.flash-messages {
+  display: grid;
+}
+
 .page {
   margin-top: 1rem;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,6 +28,14 @@ body {
   grid-template-columns: 2fr 12fr;
 }
 
+.skip-link {
+  color: white;
+}
+
+.skip-link:focus {
+  color: blue;
+}
+
 .nav {
   display: grid;
   justify-items: center;

--- a/app/controllers/address_prompt_controller.rb
+++ b/app/controllers/address_prompt_controller.rb
@@ -2,25 +2,4 @@ class AddressPromptController < ApplicationController
   def new
     @address = Address.new(session.delete(:address_params))
   end
-
-  def create
-    user = User.find(current_user.id)
-    @address = Address.create(address_params)
-    @address.user_id = user.id
-    if @address.save
-      flash[:success] = 'Address successfully saved'
-      redirect_to user_dashboard_path
-    else
-      flash[:failure] = 'Please fill out all required fields'
-      flash[:error] = @address.errors.full_messages.to_sentence
-      session[:params] = address_params
-      render :new
-    end
-  end
-
-  private
-
-  def address_params
-    params.permit(:address_first, :address_second, :city, :state, :zip)
-  end
 end

--- a/app/controllers/address_prompt_controller.rb
+++ b/app/controllers/address_prompt_controller.rb
@@ -1,0 +1,26 @@
+class AddressPromptController < ApplicationController
+  def new
+    @address = Address.new(session.delete(:address_params))
+  end
+
+  def create
+    user = User.find(current_user.id)
+    @address = Address.create(address_params)
+    @address.user_id = user.id
+    if @address.save
+      flash[:success] = 'Address successfully saved'
+      redirect_to user_dashboard_path
+    else
+      flash[:failure] = 'Please fill out all required fields'
+      flash[:error] = @address.errors.full_messages.to_sentence
+      session[:params] = address_params
+      render :new
+    end
+  end
+
+  private
+
+  def address_params
+    params.permit(:address_first, :address_second, :city, :state, :zip)
+  end
+end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -5,6 +5,9 @@ class AddressesController < ApplicationController # rubocop:todo Style/Documenta
     @address = Address.new(session.delete(:address_params))
   end
 
+  def show
+  end
+
   def create # rubocop:todo Metrics/AbcSize
     user = User.find(current_user.id)
     @address = Address.create(address_params)

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -11,12 +11,12 @@ class AddressesController < ApplicationController # rubocop:todo Style/Documenta
     @address.user_id = user.id
     if @address.save
       flash[:success] = 'Address successfully saved'
-      redirect_to root_path
+      redirect_to user_dashboard_path
     else
       flash[:failure] = 'Please fill out all required fields'
       flash[:error] = @address.errors.full_messages.to_sentence
-      session[:params] = address_params
-      render :new
+      session[:address_params] = address_params
+      redirect_to request.referrer
     end
   end
 

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -6,6 +6,7 @@ class AddressesController < ApplicationController # rubocop:todo Style/Documenta
   end
 
   def show
+    @borrower = Address.find(params[:id]).user
   end
 
   def create # rubocop:todo Metrics/AbcSize

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -15,6 +15,12 @@ class BorrowRequestsController < ApplicationController
     redirect_to address_path(borrow_request.borrower.address)
   end
 
+  def create
+    user_book_id = UserBook.find_by(user_id: params[:friend_id], book_id: params[:friend_book_id], status: 'available').id
+    a = BorrowRequest.new(status: 0, user_book_id: user_book_id, borrower_id: params[:user_id])
+    a.save
+  end
+
   def destroy
     borrow_request = BorrowRequest.find(params[:id])
     borrow_request.update(status: 1)

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -1,6 +1,7 @@
 class BorrowRequestsController < ApplicationController
   def index
-    @requests = current_user.incoming_book_borrow_requests
+    @incoming_requests = current_user.incoming_book_borrow_requests
+    @outgoing_requests = current_user.borrow_requests.where(status: 'pending')
   end
 
   def show
@@ -17,8 +18,9 @@ class BorrowRequestsController < ApplicationController
 
   def create
     user_book_id = UserBook.find_by(user_id: params[:friend_id], book_id: params[:friend_book_id], status: 'available').id
-    a = BorrowRequest.new(status: 0, user_book_id: user_book_id, borrower_id: params[:user_id])
-    a.save
+    borrow_request = BorrowRequest.new(status: 0, user_book_id: user_book_id, borrower_id: params[:user_id])
+    borrow_request.save
+    redirect_to borrow_index_path
   end
 
   def destroy

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -9,24 +9,29 @@ class BorrowRequestsController < ApplicationController
     @address = Address.includes(:user).find_by(user_id: borrow_request.borrower_id)
   end
 
-  def create
-    friend_book = UserBook.where(user_id: params[:friend_id], book_id: params[:friend_book_id]).first
-    if friend_book.status == 'available'
-      BorrowRequest.create(status: 0, user_book: friend_book, borrower_id: params[:user_id])
-      friend_book.update(status: 'unavailable')
-      flash[:success] = "Borrow Request sent to #{User.find(params[:friend_id]).full_name}"
-      redirect_to books_path
-    end
-  end
-
   def update
     borrow_request = BorrowRequest.find(params[:id])
-    borrow_request.declined!
-    decline_message = "You have declined #{borrow_request.borrower.first_name}'s " +
-                      "request to borrow #{borrow_request.user_book.book.title}"
-    flash[:success] = decline_message
-    redirect_to user_dashboard_path
+    borrow_request.approve_request
+    redirect_to address_path(borrow_request.borrower.address)
   end
+  # def create
+  #   friend_book = UserBook.where(user_id: params[:friend_id], book_id: params[:friend_book_id]).first
+  #   if friend_book.status == 'available'
+  #     BorrowRequest.create(status: 0, user_book: friend_book, borrower_id: params[:user_id])
+  #     friend_book.update(status: 'unavailable')
+  #     flash[:success] = "Borrow Request sent to #{User.find(params[:friend_id]).full_name}"
+  #     redirect_to books_path
+  #   end
+  # end
+  #
+  # def update
+  #   borrow_request = BorrowRequest.find(params[:id])
+  #   borrow_request.declined!
+  #   decline_message = "You have declined #{borrow_request.borrower.first_name}'s " +
+  #                     "request to borrow #{borrow_request.user_book.book.title}"
+  #   flash[:success] = decline_message
+  #   redirect_to user_dashboard_path
+  # end
 
   private
 

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -28,6 +28,6 @@ class BorrowRequestsController < ApplicationController
 
   def approve_request(request)
     request.user_book.update(status: 'unavailable')
-    request.accepted!
+    request.update(status: 2)
   end
 end

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -1,4 +1,8 @@
 class BorrowRequestsController < ApplicationController
+  def index
+    @requests = current_user.incoming_book_borrow_requests
+  end
+
   def show
     borrow_request = BorrowRequest.find(params[:id])
     approve_request(borrow_request)

--- a/app/controllers/borrow_requests_controller.rb
+++ b/app/controllers/borrow_requests_controller.rb
@@ -14,29 +14,13 @@ class BorrowRequestsController < ApplicationController
     borrow_request.approve_request
     redirect_to address_path(borrow_request.borrower.address)
   end
-  # def create
-  #   friend_book = UserBook.where(user_id: params[:friend_id], book_id: params[:friend_book_id]).first
-  #   if friend_book.status == 'available'
-  #     BorrowRequest.create(status: 0, user_book: friend_book, borrower_id: params[:user_id])
-  #     friend_book.update(status: 'unavailable')
-  #     flash[:success] = "Borrow Request sent to #{User.find(params[:friend_id]).full_name}"
-  #     redirect_to books_path
-  #   end
-  # end
-  #
-  # def update
-  #   borrow_request = BorrowRequest.find(params[:id])
-  #   borrow_request.declined!
-  #   decline_message = "You have declined #{borrow_request.borrower.first_name}'s " +
-  #                     "request to borrow #{borrow_request.user_book.book.title}"
-  #   flash[:success] = decline_message
-  #   redirect_to user_dashboard_path
-  # end
 
-  private
-
-  def approve_request(request)
-    request.user_book.update(status: 'unavailable')
-    request.update(status: 2)
+  def destroy
+    borrow_request = BorrowRequest.find(params[:id])
+    borrow_request.update(status: 1)
+    decline_message = "You have declined #{borrow_request.borrower.first_name}'s " +
+                      "request to borrow #{borrow_request.user_book.book.title}"
+    flash[:success] = decline_message
+    redirect_to user_dashboard_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,11 @@ class SessionsController < ApplicationController
   def create
     user = User.update_or_create(request.env['omniauth.auth'])
     session[:id] = user.id
-    redirect_to root_path
+    if user.address.nil?
+      redirect_to '/address/prompt'
+    else
+      redirect_to user_dashboard_path
+    end
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,7 @@ class SessionsController < ApplicationController
   def create
     user = User.update_or_create(request.env['omniauth.auth'])
     session[:id] = user.id
+    flash[:success] = "Welcome #{user.full_name}!"
     if user.address.nil?
       redirect_to '/address/prompt'
     else

--- a/app/controllers/user/dashboard_controller.rb
+++ b/app/controllers/user/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class User::DashboardController < ApplicationController
   def show
-    @borrow_requests = BorrowRequestFacade.incoming_book_borrow_requests(current_user)
+    @friend_requests = current_user.current_friend_requests
+    @book_requests = BorrowRequestFacade.incoming_book_borrow_requests(current_user)
   end
 end

--- a/app/models/borrow_request.rb
+++ b/app/models/borrow_request.rb
@@ -13,4 +13,11 @@ class BorrowRequest < ApplicationRecord
   def status_changed_to_returned
     self.status = 3
   end
+
+  def approve_request
+    self.update(status: 2)
+    self.save
+    user_book.update(status: 'unavailable')
+    user_book.save
+  end
 end

--- a/app/views/address_prompt/new.html.erb
+++ b/app/views/address_prompt/new.html.erb
@@ -1,0 +1,24 @@
+<% if current_user.address.nil? %>
+  <p>
+    Thank you for authorizing ShelfShare to manage your books! <br/>
+    ShelfShare is a platform for sharing books via mail. <br/>
+    You can borrow and lend books with your friends! <br/>
+    To participate fully in the shipping process, we kindly ask for your address. <br/>
+    Your address will be shown to other users when only when it is necessary to ship a book. <br/>
+    You can edit or delete your address at any time by visiting your profile. <br/>
+  </p>
+  <section class="new-address-form">
+    <%= render partial: 'partials/new_address_form', locals: { address: @address, path: 'prompt' } %>
+  </section>
+  <p>
+    DISCLAIMER: The ShelfShare platform is a proof-of-concept and not likely to be maintained over time. <br/>
+    Thus, any address information submitted will remain in our database indefinitely unless you delete it. <br/>
+    For concerns regarding your privacy, please do not submit any real location information to this website.
+  </p>
+<% end %>
+
+<% unless current_user.address.nil? %>
+  <p>
+    You have already added an address. You can manage your address information from your <%= link_to 'profile page', '/profile'%>.
+  </p>
+<% end %>

--- a/app/views/address_prompt/new.html.erb
+++ b/app/views/address_prompt/new.html.erb
@@ -4,11 +4,11 @@
     ShelfShare is a platform for sharing books via mail. <br/>
     You can borrow and lend books with your friends! <br/>
     To participate fully in the shipping process, we kindly ask for your address. <br/>
-    Your address will be shown to other users when only when it is necessary to ship a book. <br/>
+    Your address will be shown to other users only when it is necessary to ship a book. <br/>
     You can edit or delete your address at any time by visiting your profile. <br/>
   </p>
   <section class="new-address-form">
-    <%= render partial: 'partials/new_address_form', locals: { address: @address, path: 'prompt' } %>
+    <%= render partial: 'partials/new_address_form', locals: { address: @address } %>
   </section>
   <p>
     DISCLAIMER: The ShelfShare platform is a proof-of-concept and not likely to be maintained over time. <br/>

--- a/app/views/address_prompt/new.html.erb
+++ b/app/views/address_prompt/new.html.erb
@@ -10,11 +10,6 @@
   <section class="new-address-form">
     <%= render partial: 'partials/new_address_form', locals: { address: @address } %>
   </section>
-  <p>
-    DISCLAIMER: The ShelfShare platform is a proof-of-concept and not likely to be maintained over time. <br/>
-    Thus, any address information submitted will remain in our database indefinitely unless you delete it. <br/>
-    For concerns regarding your privacy, please do not submit any real location information to this website.
-  </p>
 <% end %>
 
 <% unless current_user.address.nil? %>

--- a/app/views/addresses/new.html.erb
+++ b/app/views/addresses/new.html.erb
@@ -1,22 +1,8 @@
-<h3><%= current_user.first_name %> <%= current_user.last_name %></h3>
-<h4>Address</h4>
+<h2>
+  <%= current_user.full_name %>
+</h2>
+<h4>
+  You haven't added an address yet. Please fill out the form below.
+</h4>
 
-<%= form_tag( {:action => 'create'}, {method: :post}) do %>
-  <%= label_tag :address_first, 'Address: *' %>
-  <%= text_field_tag :address_first, "#{@address.address_first}"%><br>
-
-  <%= label_tag :address_second, 'Address: ' %>
-  <%= text_field_tag :address_second, "#{@address.address_second}" %><br>
-
-  <%= label_tag :city, 'City: *' %>
-  <%= text_field_tag :city, "#{@address.city}" %><br>
-
-  <%= label_tag :state, 'State: *' %>
-  <%= text_field_tag :state, "#{@address.state}" %><br>
-
-  <%= label_tag :zip, 'Zip: *' %>
-  <%= text_field_tag :zip, "#{@address.zip}" %><br>
-
-  <%= submit_tag 'Submit Address' %>
-<% end %>
-<p>*Required Field</p>
+<%= render partial: 'partials/new_address_form', locals: { address: @address } %>

--- a/app/views/addresses/show.html.erb
+++ b/app/views/addresses/show.html.erb
@@ -1,0 +1,3 @@
+<p>Please copy the below address to ship to!</p>
+
+<%= render partial: '/partials/address_info', locals: {friend: @borrower} %>

--- a/app/views/borrow_requests/index.html.erb
+++ b/app/views/borrow_requests/index.html.erb
@@ -1,0 +1,10 @@
+<h1>Borrow Requests</h1>
+
+<section class="pending-requests">
+  <h1>Incoming Borrow Requests</h1>
+  <% @requests.each do |request| %>
+    <article class="book-request">
+      <%= "#{request.borrower.full_name} wants to borrow #{request.user_book.book.title}" %>
+    </article>
+  <% end %>
+</section>

--- a/app/views/borrow_requests/index.html.erb
+++ b/app/views/borrow_requests/index.html.erb
@@ -1,12 +1,27 @@
 <h1>Borrow Requests</h1>
 
-<section class="pending-requests">
+<section class="incoming-pending-requests">
   <h1>Incoming Borrow Requests</h1>
-  <% @requests.each do |request| %>
-    <article class="book-request">
-      <%= "#{request.borrower.full_name} wants to borrow #{request.user_book.book.title}" %>
-      <%= button_to "Approve", borrow_path(request), method: :patch %>
-      <%= button_to "Decline", borrow_path(request), method: :delete %>
-    </article>
+  <% unless @incoming_requests.nil? %>
+    <% @incoming_requests.each do |request| %>
+      <article class="book-request">
+        <%= "#{request.borrower.full_name} wants to borrow #{request.user_book.book.title}" %>
+        <%= button_to "Approve", borrow_path(request), method: :patch %>
+        <%= button_to "Decline", borrow_path(request), method: :delete %>
+      </article>
+    <% end %>
+    <%= tag.p "You have no requests" if @incoming_requests.nil? %>
   <% end %>
+</section>
+
+<section class="outgoing-pending-requests">
+  <h1>Outgoing Borrow Requests</h1>
+  <% unless @outgoing_requests.nil? %>
+    <% @outgoing_requests.each do |request| %>
+      <article class="book-request">
+        You asked to borrow <%= request.user_book.book.title %> from <%= request.borrower.full_name %>
+      </article>
+    <% end %>
+  <% end %>
+  <%= tag.p "You have no requests" if @outgoing_requests.nil? %>
 </section>

--- a/app/views/borrow_requests/index.html.erb
+++ b/app/views/borrow_requests/index.html.erb
@@ -5,6 +5,8 @@
   <% @requests.each do |request| %>
     <article class="book-request">
       <%= "#{request.borrower.full_name} wants to borrow #{request.user_book.book.title}" %>
+      <%= button_to "Approve", borrow_path(request), method: :patch %>
+      <%= button_to "Decline" %>
     </article>
   <% end %>
 </section>

--- a/app/views/borrow_requests/index.html.erb
+++ b/app/views/borrow_requests/index.html.erb
@@ -6,7 +6,7 @@
     <article class="book-request">
       <%= "#{request.borrower.full_name} wants to borrow #{request.user_book.book.title}" %>
       <%= button_to "Approve", borrow_path(request), method: :patch %>
-      <%= button_to "Decline" %>
+      <%= button_to "Decline", borrow_path(request), method: :delete %>
     </article>
   <% end %>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,13 @@
   <body>
      <% if current_user %>
       <nav>
-        <%= link_to "Home", root_path %>
+        <header>
+          <a class="skip-link" href='#main'>Skip to content</a>
+        </header>
+
+        <%= link_to "ShelfShare", root_path %>
         <%= link_to "Dashboard", user_dashboard_path %>
-        <%= link_to "Browse Books", books_path %>
+        <%= link_to "Books", books_path %>
         <%= link_to "Friends", user_friends_path %>
         <%= link_to "Profile", user_books_path %>
         <span>
@@ -24,7 +28,6 @@
           (<%= link_to "Logout", logout_path %>)
         </span>
       </nav>
-
     <% end %>
     <% flash.each do |name, msg| %>
       <% if name == "missing_details" %>
@@ -39,6 +42,8 @@
         </div>
       <% end %>
     <% end %>
-    <%= yield %>
+    <main id="main" tabindex="-1">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
      <% if current_user %>
-      <nav>
+      <nav class="nav">
         <header>
           <a class="skip-link" href='#main'>Skip to content</a>
         </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,15 @@
         <%= link_to "Dashboard", user_dashboard_path %>
         <%= link_to "Browse Books", books_path %>
         <%= link_to "Friends", user_friends_path %>
-        <%= link_to "My Books", user_books_path %>
-        <%= link_to "Account Info", user_account_path %>
+        <%= link_to "Profile", user_books_path %>
+        <span>
+          <%= "Logged in as #{current_user.first_name}"%>.
+        </span>
+        <span>
+          (<%= link_to "Logout", logout_path %>)
+        </span>
       </nav>
+
     <% end %>
     <% flash.each do |name, msg| %>
       <% if name == "missing_details" %>

--- a/app/views/partials/_address_disclaimer.html.erb
+++ b/app/views/partials/_address_disclaimer.html.erb
@@ -1,0 +1,6 @@
+<p>
+  DISCLAIMER: <br/>
+  The ShelfShare platform is a proof-of-concept and not likely to be maintained over time. <br/>
+  Thus, any address information submitted will remain in our database indefinitely unless you delete it. <br/>
+  For concerns regarding your privacy, please do not submit any real location information to this website.
+</p>

--- a/app/views/partials/_address_info.html.erb
+++ b/app/views/partials/_address_info.html.erb
@@ -1,0 +1,8 @@
+<ul style="list-style-type:none;">
+  <li><%= friend.full_name %></li>
+  <li><%= friend.address.address_first %></li>
+    <% if friend.address.address_second.present? %>
+      <li><%= friend.address.address_second %></li>
+    <% end %>
+  <li><%= friend.address.city %>, <%= friend.address.state %>, <%= friend.address.zip %> </li>
+</ul>

--- a/app/views/partials/_new_address_form.html.erb
+++ b/app/views/partials/_new_address_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_tag path, method: :post do %>
+  <%= label_tag :address_first, 'Address: *' %>
+  <%= text_field_tag :address_first, "#{@address.address_first}"%><br>
+
+  <%= label_tag :address_second, 'Address: ' %>
+  <%= text_field_tag :address_second, "#{@address.address_second}" %><br>
+
+  <%= label_tag :city, 'City: *' %>
+  <%= text_field_tag :city, "#{@address.city}" %><br>
+
+  <%= label_tag :state, 'State: *' %>
+  <%= text_field_tag :state, "#{@address.state}" %><br>
+
+  <%= label_tag :zip, 'Zip: *' %>
+  <%= text_field_tag :zip, "#{@address.zip}" %><br>
+
+  <%= submit_tag 'Submit Address' %>
+<% end %>
+<p>*Required Field</p>

--- a/app/views/partials/_new_address_form.html.erb
+++ b/app/views/partials/_new_address_form.html.erb
@@ -16,3 +16,5 @@
 
   <%= submit_tag 'Submit Address' %>
 <% end %>
+
+<%= render 'partials/address_disclaimer' %>

--- a/app/views/partials/_new_address_form.html.erb
+++ b/app/views/partials/_new_address_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag path, method: :post do %>
+<%= form_tag addresses_path do %>
   <%= label_tag :address_first, 'Address: *' %>
   <%= text_field_tag :address_first, "#{@address.address_first}"%><br>
 
@@ -16,4 +16,3 @@
 
   <%= submit_tag 'Submit Address' %>
 <% end %>
-<p>*Required Field</p>

--- a/app/views/return/index.html.erb
+++ b/app/views/return/index.html.erb
@@ -7,7 +7,7 @@
 <!-- borrow_request.user_book.book -->
 <% @borrow_requests.each do |br| %>
 <div class="borrowed-books" id="borrow-<%= br.id %>">
-  <%= book = br.user_book.book %>
+  <% book = br.user_book.book %>
   <%= image_tag(book.thumbnail, alt: "#{book.title} cover image") %>
   <%= button_to "Return", "/return/#{br.user_book.user_id}", params:{user_book_id: br.user_book.id, borrow_request_id: br.id}, method: :get %>
 </div>

--- a/app/views/return/show.html.erb
+++ b/app/views/return/show.html.erb
@@ -4,11 +4,4 @@
 
 <h4><%= @friend.first_name %> Address:</h4>
 
-<ul style="list-style-type:none;">
-  <li><%= @friend.full_name %></li>
-  <li><%= @friend.address.address_first %></li>
-  <% if @friend.address.address_second.present? %>
-  <li><%= @friend.address.address_second %></li>
-  <% end %>
-  <li><%= @friend.address.city %>, <%= @friend.address.state %>, <%= @friend.address.zip %> </li>
-</ul>
+<%= render partial: '/partials/address_info', locals: {friend: @friend} %>

--- a/app/views/user/books/index.html.erb
+++ b/app/views/user/books/index.html.erb
@@ -1,6 +1,8 @@
 <h3><%= current_user.first_name %>'s Book Shelf</h3>
 <%= link_to "Add Books to My Shelf", new_user_book_path %>
 
+<%= link_to "My Shipping Information", current_user.address.nil? ? new_address_path : user_account_path %>
+
 <h5>Off The Shelf</h5>
 <% if @unavailable_books.present?  %>
   <% @unavailable_books.each do |book| %>

--- a/app/views/user/books/index.html.erb
+++ b/app/views/user/books/index.html.erb
@@ -4,14 +4,14 @@
 <%= link_to "My Shipping Information", current_user.address.nil? ? new_address_path : user_account_path %>
 
 <section class="available-books">
-  <h5>On The Shelf</h5>
-  <% if @available_books.present?  %>
-    <% @available_books.each do |book| %>
-      <%= link_to book.title, user_book_path(book) %>
-    <% end %>
-  <% else %>
-    <p>No books are currently available</p>
+<h5>On The Shelf</h5>
+<% if @available_books.present?  %>
+  <% @available_books.each do |book| %>
+    <%= link_to book.title, user_book_path(book) %>
   <% end %>
+<% else %>
+  <p>No books are currently available</p>
+<% end %>
 </section>
 
 <section class="unavailable-books">

--- a/app/views/user/dashboard/show.html.erb
+++ b/app/views/user/dashboard/show.html.erb
@@ -1,12 +1,12 @@
 <h1>My Dashboard</h1>
 
-<section class="book-requests">
+<section class="book-requests" tabindex="0">
   <header>
     <h4>Book Requests</h4>
   </header>
-  <section class="pending-requests">
+  <section class="pending-requests"">
     <% @borrow_requests.each do |request| %>
-      <article class="request">
+      <article class="request" tabindex="0">
         <%= "#{request.borrower} wants to borrow #{request.book_title}" %>
         <%= button_to "Accept", borrow_path(request.id), { method: :get } %>
         <%= button_to "Decline", borrow_path(request.id), { method: :patch } %>
@@ -15,32 +15,44 @@
   </section>
 </section>
 
-<section class="borrowed-books">
+<section class="borrowed-books" tabindex="0">
   <header>
     <h4>Borrowed Books</h4>
     <%= button_to "See all borrowed books", "/return", method: :get %>
   </header>
 </section>
 
-<section class="loaned-books">
+<section class="loaned-books" tabindex="0">
   <header>
     <h4>Loaned books</h4>
   </header>
 </section>
 
-<section class="friend-requests">
+<section class="friend-requests" tabindex="0">
   <header>
     <h4>Friend Requests</h4>
   </header>
+  <% friend_requests = current_user.current_friend_requests %>
+  <% if friend_requests.empty? %>
+    <p>No pending friend requests</p>
+  <% else %>
+
+    <p>
+      You have
+      <a href="<%= user_friends_path %>">
+        <%= pluralize friend_requests.size, "new friend request" %>
+      </a>
+    </p>
+  <% end %>
 </section>
 
-<section class="recommendations">
+<section class="recommendations" tabindex="0">
   <header>
     <h4>Recommendations</h4>
   </header>
 </section>
 
-<section class="in-transit">
+<section class="in-transit" tabindex="0">
   <header>
     <h4>In Transit</h4>
   </header>

--- a/app/views/user/dashboard/show.html.erb
+++ b/app/views/user/dashboard/show.html.erb
@@ -4,8 +4,18 @@
   <header>
     <h4>Book Requests</h4>
   </header>
-  <section class="pending-requests"">
-    <% @borrow_requests.each do |request| %>
+  <% if @book_requests.empty? %>
+    <p>No current requests</p>
+  <% else %>
+    <p>
+      You have
+      <a href="<%= borrow_index_path %>">
+        <%= pluralize @book_requests.size, "new book request" %>
+      </a>
+    </p>
+  <% end %>
+  <section class="pending-requests">
+    <% @book_requests.each do |request| %>
       <article class="request" tabindex="0">
         <%= "#{request.borrower} wants to borrow #{request.book_title}" %>
         <%= button_to "Accept", borrow_path(request.id), { method: :get } %>
@@ -32,24 +42,16 @@
   <header>
     <h4>Friend Requests</h4>
   </header>
-  <% friend_requests = current_user.current_friend_requests %>
-  <% if friend_requests.empty? %>
+  <% if @friend_requests.empty? %>
     <p>No pending friend requests</p>
   <% else %>
-
     <p>
       You have
       <a href="<%= user_friends_path %>">
-        <%= pluralize friend_requests.size, "new friend request" %>
+        <%= pluralize @friend_requests.size, "new friend request" %>
       </a>
     </p>
   <% end %>
-</section>
-
-<section class="recommendations" tabindex="0">
-  <header>
-    <h4>Recommendations</h4>
-  </header>
 </section>
 
 <section class="in-transit" tabindex="0">

--- a/app/views/user/dashboard/show.html.erb
+++ b/app/views/user/dashboard/show.html.erb
@@ -14,15 +14,6 @@
       </a>
     </p>
   <% end %>
-  <section class="pending-requests">
-    <% @book_requests.each do |request| %>
-      <article class="request" tabindex="0">
-        <%= "#{request.borrower} wants to borrow #{request.book_title}" %>
-        <%= button_to "Accept", borrow_path(request.id), { method: :get } %>
-        <%= button_to "Decline", borrow_path(request.id), { method: :patch } %>
-      </article>
-    <% end %>
-  </section>
 </section>
 
 <section class="borrowed-books" tabindex="0">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,7 +1,5 @@
 <h1>Welcome to ShelfShare!</h1>
 
-<% if current_user %>
-  <h3>Welcome <%= "#{current_user.first_name} #{current_user.last_name}!" %></h3>
-<% else  %>
+<% unless current_user %>
   <%= link_to "Sign in with Google", "/auth/google_oauth2" %>
 <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,10 +2,6 @@
 
 <% if current_user %>
   <h3>Welcome <%= "#{current_user.first_name} #{current_user.last_name}!" %></h3>
-    <% if current_user.address.nil? %>
-      <%= button_to "Add Address", { :action => "new", :controller => "addresses" }, :method => :get %>
-    <% end %>
-  <%= link_to "Logout", logout_path %>
 <% else  %>
   <%= link_to "Sign in with Google", "/auth/google_oauth2" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   get 'logout', to: 'sessions#destroy'
   resources :addresses, only: %i[new create update edit]
 
+  get 'address/prompt', to: 'address_prompt#new'
+  post 'address/prompt', to: 'address_prompt#create'
+
   namespace :books do
     resources :search, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show]
 
-  resources :borrow_requests, as: 'borrow', only: [:show, :create, :update, :index]
+  resources :borrow_requests, as: 'borrow', only: [:show, :create, :update, :index, :destroy]
 
   resources :return, only: [:index, :show]
   namespace :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
   resources :addresses, only: %i[new create update edit]
 
   get 'address/prompt', to: 'address_prompt#new'
-  post 'address/prompt', to: 'address_prompt#create'
 
   namespace :books do
     resources :search, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show]
 
-  resources :borrow_requests, as: 'borrow', only: [:show, :create, :update, :index, :destroy]
+  resources :borrow_requests, as: 'borrow', only: [:show, :update, :index, :destroy]
 
   resources :return, only: [:index, :show]
   namespace :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'logout', to: 'sessions#destroy'
-  resources :addresses, only: %i[new create update edit]
+  resources :addresses, only: %i[new create update edit show]
 
   get 'address/prompt', to: 'address_prompt#new'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show]
 
-  resources :borrow_requests, as: 'borrow', only: [:show, :create, :update]
+  resources :borrow_requests, as: 'borrow', only: [:show, :create, :update, :index]
 
   resources :return, only: [:index, :show]
   namespace :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :books, only: [:index, :show]
 
-  resources :borrow_requests, as: 'borrow', only: [:show, :update, :index, :destroy]
+  resources :borrow_requests, as: 'borrow', except: [:new, :edit] # [:show, :update, :index, :destroy, :create]
 
   resources :return, only: [:index, :show]
   namespace :user do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     status { 'available' }
   end
 
-  factory :borrow_request do
+  factory :borrow_request, aliases: [:request] do
     borrower
     user_book
     status { 'pending' }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     category { Faker::Book.genre }
   end
 
-  factory :user, aliases: [:borrower] do
+  factory :user, aliases: [:borrower, :friend] do
     faker_omniauth = Faker::Omniauth.new
     provider { 'google' }
     uid { Faker::Internet.uuid }

--- a/spec/features/address/prompt_for_address_after_login_spec.rb
+++ b/spec/features/address/prompt_for_address_after_login_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "Address Prompt Page Spec" do
+  before :each do
+    @prompt = "Thank you for authorizing ShelfShare to manage your books! " +
+              "ShelfShare is a platform for sharing books via mail. " +
+              "You can borrow and lend books with your friends! " +
+              "To participate fully in the shipping process, we kindly ask for your address. " +
+              "Your address will be shown to other users when only when it is necessary to ship a book. " +
+              "You can edit or delete your address at any time by visiting your profile."
+
+    @disclaimer = "DISCLAIMER: " +
+                  "The ShelfShare platform is a proof-of-concept and not likely to be maintained over time. " +
+                  "Thus, any address information submitted will remain in our database indefinitely unless you delete it. " +
+                  "For concerns regarding your privacy, please do not submit any real location information to this website."
+
+    @message = 'You have already added an address. ' +
+               'You can manage your address information from your profile page'
+  end
+
+  it "There is a prompt to add address when logging in" do
+    login_as_user
+    expect(current_path).to eq('/address/prompt')
+    expect(page).to have_content(@prompt)
+    expect(page).to have_content(@disclaimer)
+    expect(page).to have_link("Add Address", href: new_address_path)
+  end
+
+  it "I can add my address from the address prompt page and I won't be prompted again" do
+    address = build(:address, address_second: "Apt 101")
+
+    login_as_user
+    expect(current_path).to eq('/address/prompt')
+    click_link("Add Address")
+    expect(current_path).to eq(new_address_path)
+
+    fill_in :address_first, with: address.address_first
+    fill_in :address_second, with: address.address_second
+    fill_in :city, with: address.city
+    fill_in :state, with: address.state
+    fill_in :zip, with: address.zip
+
+    expect(current_user.address).to be_falsey
+    click_button 'Submit Address'
+    expect(page).to have_content('Address successfully saved')
+    expect(current_user.address).to be_truthy
+
+    visit root_path
+    click_link "Logout"
+    click_link 'Sign in with Google'
+
+    expect(current_path).to eq(user_dashboard_path)
+
+    visit '/address/prompt'
+    expect(page).to_not have_content(@prompt)
+    expect(page).to_not have_content(@disclaimer)
+    expect(page).to have_content(@message)
+    expect(page).to have_link('profile page')
+  end
+
+  it "If I have an address, I do not see the prompt when visiting the address prompt page" do
+    user = create(:user)
+    create(:address, user: user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit '/address/prompt'
+    expect(page).to_not have_content(@prompt)
+    expect(page).to_not have_content(@disclaimer)
+    expect(page).to have_content(@message)
+    expect(page).to have_link('profile page')
+  end
+end

--- a/spec/features/address/prompt_for_address_after_login_spec.rb
+++ b/spec/features/address/prompt_for_address_after_login_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Address Prompt Page Spec" do
     expect(current_path).to eq('/address/prompt')
     expect(page).to have_content(@prompt)
     expect(page).to have_content(@disclaimer)
-    expect(page).to have_link("Add Address", href: new_address_path)
+    expect(page).to have_css(".new-address-form")
   end
 
   it "I can add my address from the address prompt page and I won't be prompted again" do
@@ -31,19 +31,20 @@ RSpec.describe "Address Prompt Page Spec" do
 
     login_as_user
     expect(current_path).to eq('/address/prompt')
-    click_link("Add Address")
-    expect(current_path).to eq(new_address_path)
 
-    fill_in :address_first, with: address.address_first
-    fill_in :address_second, with: address.address_second
-    fill_in :city, with: address.city
-    fill_in :state, with: address.state
-    fill_in :zip, with: address.zip
+    expect do
+      within ".new-address-form" do
+        fill_in :address_first, with: address.address_first
+        fill_in :address_second, with: address.address_second
+        fill_in :city, with: address.city
+        fill_in :state, with: address.state
+        fill_in :zip, with: address.zip
+        click_button 'Submit Address'
+      end
+    end.to change { current_user.address }.from(nil).to(be_truthy)
 
-    expect(current_user.address).to be_falsey
-    click_button 'Submit Address'
+    expect(current_path).to eq(user_dashboard_path)
     expect(page).to have_content('Address successfully saved')
-    expect(current_user.address).to be_truthy
 
     visit root_path
     click_link "Logout"

--- a/spec/features/address/prompt_for_address_after_login_spec.rb
+++ b/spec/features/address/prompt_for_address_after_login_spec.rb
@@ -70,4 +70,33 @@ RSpec.describe "Address Prompt Page Spec" do
     expect(page).to have_content(@message)
     expect(page).to have_link('profile page')
   end
+
+
+  scenario 'Submitting an incomplete form redirects me to the form page with a flash message indicating the error. All fields are pre-populated with what was initially submitted' do
+    address = build(:address, address_second: "Apt 101")
+
+    login_as_user
+    expect(current_path).to eq('/address/prompt')
+
+    within ".new-address-form" do
+      fill_in :address_first, with: address.address_first
+      fill_in :address_second, with: address.address_second
+      # fill_in :city, with: address.city
+      fill_in :state, with: address.state
+      fill_in :zip, with: address.zip
+      click_button 'Submit Address'
+    end
+
+    expect(current_user.address).to be_falsey
+    expect(current_path).to eq('/address/prompt')
+    expect(page).to have_content('Please fill out all required fields')
+    expect(page).to have_content("City can't be blank")
+    expect(page).to_not have_field(:city, with: address.city)
+
+    expect(page).to have_field(:address_first, with: address.address_first)
+    expect(page).to have_field(:address_second, with: address.address_second)
+    expect(page).to have_field(:state, with: address.state)
+    expect(page).to have_field(:zip, with: address.zip)
+
+  end
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'User Book Index Page' do
                       book_id: @book2.id,
                       status: 'unavailable'
                     })
-    visit 'user/books'
+    visit user_books_path
     expect(page).to have_content(@book1.title)
     expect(page).to have_content(@book2.title)
     expect(page).to have_content("On The Shelf")
@@ -38,7 +38,7 @@ RSpec.describe 'User Book Index Page' do
                       book_id: @book2.id,
                       status: 'unavailable'
                     })
-    visit 'user/books'
+    visit user_books_path
     expect(page).to have_content(@book1.title)
     expect(page).to have_content(@book2.title)
     expect(page).to have_content("On The Shelf")
@@ -57,7 +57,7 @@ RSpec.describe 'User Book Index Page' do
                       book_id: @book2.id,
                       status: 'available'
                     })
-    visit 'user/books'
+    visit user_books_path
     expect(page).to have_content(@book1.title)
     expect(page).to have_content(@book2.title)
     expect(page).to have_content("On The Shelf")

--- a/spec/features/borrowing/borrow_requests_index_spec.rb
+++ b/spec/features/borrowing/borrow_requests_index_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Borrow Requests Index Page Spec" do
     end
     it 'the index only has pending book requests' do
       visit borrow_index_path
-      within ".pending-requests" do
+      within ".incoming-pending-requests" do
         expect(page).to have_content("Incoming Borrow Requests")
         book_request = find(".book-request", match: :first)
         message = "#{@borrow_request1.borrower.full_name} wants to borrow #{@borrow_request1.user_book.book.title}"

--- a/spec/features/borrowing/borrow_requests_index_spec.rb
+++ b/spec/features/borrowing/borrow_requests_index_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Borrow Requests Index Page Spec" do
+  before :each do
+    @user1, @user2 = create_list(:user, 2)
+    @user1.friends << @user2
+    @user2.friends << @user1
+    @book = create(:book)
+    @user_book1 = create(:user_book, user: @user2, book: @book)
+    @user_book2 = create(:user_book, user: @user2, book: @book, status: 'unavailable')
+    @borrow_request1 = create(:borrow_request, borrower: @user1, user_book: @user_book1)
+    @borrow_request2 = create(:borrow_request, borrower: @user1, user_book: @user_book2, status: 2)
+    # user1 is asking for a book from user2
+  end
+
+  it 'can pass the model assertions for incoming_book_borrow_requests' do
+    expect(@user2.incoming_book_borrow_requests).to include(@borrow_request1)
+    expect(@user2.incoming_book_borrow_requests).to_not include(@borrow_request2)
+  end
+
+  describe 'feature' do
+    before :each do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)
+    end
+    it 'has borrow_request notification on the dashboard' do
+      visit user_dashboard_path
+      within ".book-requests" do
+        expect(page).to have_content("You have 1 new book request")
+      end
+    end
+    it 'can click to borrow_requests on the index page' do
+      visit user_dashboard_path
+      within ".book-requests" do
+        click_on("1 new book request")
+      end
+      expect(current_path).to eq(borrow_index_path)
+    end
+    it 'the index only has pending book requests' do
+      visit borrow_index_path
+      within ".pending-requests" do
+        expect(page).to have_content("Incoming Borrow Requests")
+        book_request = find(".book-request", match: :first)
+        message = "#{@borrow_request1.borrower.full_name} wants to borrow #{@borrow_request1.user_book.book.title}"
+        expect(page).to have_content(message)
+        expect(page).to_not have_content(@borrow_request2.user_book.book)
+      end
+    end
+  end
+end

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -1,18 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "Borrowing Spec 1/?" do
-  it "I can send a book borrow request to my friend"
+  before :each do
+    @borrower = create(:borrower)
+    @librarian = create(:user)
+    @address1 = create(:address, user: @borrower, address_second: "Apt 101")
+    @address2 = create(:address, user: @librarian, address_second: "Apt 222")
+    @borrower.friends << @librarian
+    @librarian.friends << @borrower
+    @book = create(:book)
+    @user_book = create(:user_book, user: @librarian, book: @book)
+    # @borrow_request = create(:borrow_request, borrower: @borrower, user_book: @user_book)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@borrower)
+    # user 1 is borrowing from user 2
+  end
+  it "I can send a book borrow request to my friend" do
+    # logged in as @borrower
+    visit books_path
+    click_link @book.title
+    expect(current_path).to eq(book_path(@book))
 
-  # TODO
-  # if i don't have an address when i ask to borrow, i will be prompted to do so
-
-  # creating a borrow request will:
-  # 1. record a borrow request with a status pending
-  # 2. remove the option for me to ask again for that book
-
-  # the pattern is back and forth between users, like friend requests
-
-  # it should not affect the status of any user_book records
-
-  # it needs to be tested in the browser
+    expect do
+      click_button "Ask to Borrow"
+    end.to change { BorrowRequest.count }.by(1)
+  end
 end

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe "Borrowing Spec 1/?" do
     @user1, @user2 = create_list(:user, 2)
     @address = create(:address, user: @user1, address_second: "Apt 101")
     @user1.friends << @user2
+    @user2.friends << @user1
     @book = create(:book)
     @user_book = create(:user_book, user: @user2, book: @book)
   end
 
   it "I can send a borrow request from my friend's book show page" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)
+    visit user_dashboard_path
+    within ".book-requests" do
+      expect(page).to have_content("No current requests")
+    end
+
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
 
     expect(BorrowRequest.count).to eq(0)
-
     expect do
       visit books_path
       click_link @book.title

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -1,37 +1,5 @@
 require "rails_helper"
 
 RSpec.describe "Borrowing Spec 1/?" do
-  before :each do
-    @user1, @user2 = create_list(:user, 2)
-    @address = create(:address, user: @user1, address_second: "Apt 101")
-    @user1.friends << @user2
-    @user2.friends << @user1
-    @book = create(:book)
-    @user_book = create(:user_book, user: @user2, book: @book)
-  end
-
-  it "I can send a borrow request from my friend's book show page" do
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)
-    visit user_dashboard_path
-    within ".book-requests" do
-      expect(page).to have_content("No current requests")
-    end
-
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
-
-    expect(BorrowRequest.count).to eq(0)
-    expect do
-      visit books_path
-      click_link @book.title
-      click_button "Ask to Borrow"
-    end.to change { BorrowRequest.count }.by(1)
-
-    request = BorrowRequest.first
-    expect(request.status).to eq("pending")
-
-    expect(current_path).to eq(books_path)
-    expect(page).to have_content("Borrow Request sent to #{@user2.full_name}")
-    click_link @book.title
-    expect(page).to_not have_button "Ask to Borrow"
-  end
+  it "I can send a book borrow request to my friend" 
 end

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -12,13 +12,17 @@ RSpec.describe "Borrowing Spec 1/?" do
   it "I can send a borrow request from my friend's book show page" do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user1)
 
+    expect(BorrowRequest.count).to eq(0)
+
     expect do
       visit books_path
       click_link @book.title
       click_button "Ask to Borrow"
     end.to change { BorrowRequest.count }.by(1)
+
     request = BorrowRequest.first
-    expect(request.status).to eq("accepted")
+    expect(request.status).to eq("pending")
+
     expect(current_path).to eq(books_path)
     expect(page).to have_content("Borrow Request sent to #{@user2.full_name}")
     click_link @book.title

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -3,8 +3,16 @@ require "rails_helper"
 RSpec.describe "Borrowing Spec 1/?" do
   it "I can send a book borrow request to my friend"
 
+  # TODO
   # if i don't have an address when i ask to borrow, i will be prompted to do so
+
   # creating a borrow request will:
   # 1. record a borrow request with a status pending
   # 2. remove the option for me to ask again for that book
+
+  # the pattern is back and forth between users, like friend requests
+
+  # it should not affect the status of any user_book records
+
+  # it needs to be tested in the browser
 end

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -23,5 +23,8 @@ RSpec.describe "Borrowing Spec 1/?" do
     expect do
       click_button "Ask to Borrow"
     end.to change { BorrowRequest.count }.by(1)
+
+    expect(current_path).to eq(borrow_index_path)
+    expect(page).to have_content("You asked to borrow #{@book.title} from #{@librarian.full_name}")
   end
 end

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "Borrowing Spec 1/?" do
       click_link @book.title
       click_button "Ask to Borrow"
     end.to change { BorrowRequest.count }.by(1)
-
+    request = BorrowRequest.first
+    expect(request.status).to eq("accepted")
     expect(current_path).to eq(books_path)
     expect(page).to have_content("Borrow Request sent to #{@user2.full_name}")
     click_link @book.title

--- a/spec/features/borrowing/initiate_spec.rb
+++ b/spec/features/borrowing/initiate_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Borrowing Spec 1/?" do
-  it "I can send a book borrow request to my friend" 
+  it "I can send a book borrow request to my friend"
+
+  # if i don't have an address when i ask to borrow, i will be prompted to do so
+  # creating a borrow request will:
+  # 1. record a borrow request with a status pending
+  # 2. remove the option for me to ask again for that book
 end

--- a/spec/features/borrowing/lender_request_spec.rb
+++ b/spec/features/borrowing/lender_request_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Borrowing Spec 2/?" do
     expect(current_path).to eq(address_path(@address1))
 
     # expect page to have all the content
+    # including a flash message
 
     @borrow_request.reload
     @user_book.reload
@@ -54,15 +55,15 @@ RSpec.describe "Borrowing Spec 2/?" do
     expect(page).to_not have_css(".book-request")
   end
 
-  xit "I can decline a request from the dashboard" do
-    visit user_dashboard_path
+  it "I can decline a request" do
+    visit borrow_index_path
 
     expect(@borrow_request.status).to eq('pending')
     expect(@user_book.status).to eq('available')
 
-    within ".pending-requests" do
-      request = find((".request"), match: :first)
-      click_button("Decline")
+    request = find((".book-request"), match: :first)
+    within request do
+      click_button "Decline"
     end
 
     @borrow_request.reload
@@ -75,8 +76,7 @@ RSpec.describe "Borrowing Spec 2/?" do
 
     expect(page).to have_content("You have declined #{@user1.first_name}'s request to borrow #{@book.title}")
 
-    within ".pending-requests" do
-      expect(page).to_not have_css(".request")
-    end
+    visit borrow_index_path
+    expect(page).to_not have_css(".book-request")
   end
 end

--- a/spec/features/borrowing/lender_request_spec.rb
+++ b/spec/features/borrowing/lender_request_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "Borrowing Spec 2/?" do
     expect(@user_book.status).to eq('unavailable')
 
     visit borrow_index_path
+    expect(page).to_not have_css(".book-request")
   end
 
   xit "I can decline a request from the dashboard" do

--- a/spec/features/borrowing/lender_request_spec.rb
+++ b/spec/features/borrowing/lender_request_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe "Borrowing Spec 2/?" do
     end
 
     expect(current_path).to eq(address_path(@address1))
-
-    # TODO
-    # this is pretty much story #
-    # expect page to have all the content
-    # including a flash message
+    expect(page).to have_content(@address1.address_first)
+    expect(page).to have_content(@address1.address_second)
+    expect(page).to have_content(@address1.city)
+    expect(page).to have_content(@address1.state)
+    expect(page).to have_content(@address1.zip)
 
     @borrow_request.reload
     @user_book.reload

--- a/spec/features/borrowing/lender_request_spec.rb
+++ b/spec/features/borrowing/lender_request_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe "Borrowing Spec 2/?" do
 
     expect(current_path).to eq(address_path(@address1))
 
+    # TODO
+    # this is pretty much story #
     # expect page to have all the content
     # including a flash message
 

--- a/spec/features/friends/book_index_spec.rb
+++ b/spec/features/friends/book_index_spec.rb
@@ -4,43 +4,44 @@ RSpec.describe 'Friend Book Index Page' do
   before :each do
     login_as_user
     @friend1 = create(:user)
-    @friend1_books = create_list(:book, 3)
-    @friend1.user_books.create!(book_id: @friend1_books[0].id, status: 'available')
-    @friend1.user_books.create!(book_id: @friend1_books[1].id, status: 'available')
-    @ub2 = @friend1.user_books.create!(book_id: @friend1_books[2].id, status: 'unavailable')
+    @book1 = create(:book, id: 111)
+    @book2 = create(:book, id: 2222, thumbnail: "https://image.shutterstock.com/image-vector/ui-image-placeholder-wireframes-apps-260nw-1037719204.jpg")
+    @book3 = create(:book, id: 345, thumbnail: "https://image.shutterstock.com/image-vector/default-ui-image-placeholder-wireframes-260nw-1037719192.jpg")
+    @friend1.user_books.create!(book_id: @book1.id, status: 'available')
+    @friend1.user_books.create!(book_id: @book2.id, status: 'available')
+    @ub2 = @friend1.user_books.create!(book_id: @book3.id, status: 'unavailable')
     current_user.friendships.create!(friend_id: @friend1.id)
     @friend1.friendships.create!(friend_id: current_user.id)
     current_user.borrow_requests.create!(user_book: @ub2, status: 2)
 
-    @book = create(:book)
-    @ub_user = current_user.user_books.create(book_id: @book.id, status: 'unavailable')
+    @book4 = create(:book, id: 97, thumbnail: "https://icons-for-free.com/iconfiles/png/512/mountains+photo+photos+placeholder+sun+icon-1320165661388177228.png")
+    @ub_user = current_user.user_books.create(book_id: @book4.id, status: 'unavailable')
     @friend1.borrow_requests.create!(user_book: @ub_user, status: 2)
   end
 
   it "I can visit a friends book index page, and it shows all of the friends available books" do
-    skip "Travis causing ambiguous xpath error"
     visit "/user/friends/#{@friend1.id}"
     expect(page).to have_content("#{@friend1.first_name}'s Books")
-    expect(page).to have_css("img[src*='#{@friend1_books[0].thumbnail}']")
-    expect(page).to have_css("img[src*='#{@friend1_books[1].thumbnail}']")
-    expect(page).to have_css("img[src*='#{@friend1_books[2].thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book1.thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book2.thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book3.thumbnail}']")
 
     expected_count = @friend1.books.available.count
     expect(page).to have_css(".available_book", count: expected_count)
 
-    within "#book-#{@friend1_books[0].id}" do
-      book_link = find(:xpath, "//a[contains(@href,#{@friend1_books[0].id})]")
+    within "#book-#{@book1.id}" do
+      book_link = find(:xpath, "//a[contains(@href,#{@book1.id})]")
       book_link.click
     end
 
-    expect(current_path).to eq("/books/#{@friend1_books[0].id}")
+    expect(current_path).to eq("/books/#{@book1.id}")
   end
 
   it 'The view page will show books that I am borrowing from my friend' do
     visit "/user/friends/#{@friend1.id}"
     expect(page).to have_css(".borrowed_from_user", count: 1)
     within('.borrowed_from_user') do
-      find(:xpath, "//a[contains(@href,#{@friend1_books[2].id})]")
+      find(:xpath, "//a[contains(@href,#{@book3.id})]")
     end
   end
 
@@ -48,8 +49,8 @@ RSpec.describe 'Friend Book Index Page' do
     visit "/user/friends/#{@friend1.id}"
     expect(page).to have_css(".lent_to_user", count: 1)
     within('.lent_to_user') do
-      find(:xpath, "//a[contains(@href,#{@book.id})]").click
+      find(:xpath, "//a[contains(@href,#{@book4.id})]").click
     end
-    expect(current_path).to eq("/books/#{@book.id}")
+    expect(current_path).to eq("/books/#{@book4.id}")
   end
 end

--- a/spec/features/friends/new_friends_spec.rb
+++ b/spec/features/friends/new_friends_spec.rb
@@ -29,7 +29,19 @@ RSpec.describe 'User Can Add friends' do
     expect(page).to have_content('No users with that email')
   end
   it 'friend requests appear on the friends page and users can accept' do
+    visit user_dashboard_path
+    within '.friend-requests' do
+      expect(page).to have_content("No pending friend requests")
+    end
+
     @user.friend_requests.create!(from: @user2.id)
+
+    visit user_dashboard_path
+    within '.friend-requests' do
+      expect(page).to_not have_content("No pending friend requests")
+      expect(page).to have_content("You have 1 new friend request")
+    end
+
 
     visit user_friends_path
 

--- a/spec/features/navigation/nav_bar_spec.rb
+++ b/spec/features/navigation/nav_bar_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe 'Navigation Bar' do
       expect(page).to have_link('Dashboard', href: user_dashboard_path)
       expect(page).to have_link('Browse Books', href: books_path)
       expect(page).to have_link('Friends', href: user_friends_path)
-      expect(page).to have_link('My Books', href: user_books_path)
-      expect(page).to have_link('Account Info', href: user_account_path)
+      expect(page).to have_link('Profile', href: user_books_path)
+      # expect(page).to have_link('Account Info', href: user_account_path)
+      expect(page).to have_content("Logged in as #{@user.first_name}. (Logout)")
+      expect(page).to have_link('Logout', href: logout_path)
     end
   end
   it 'has working paths for all links' do
@@ -26,11 +28,15 @@ RSpec.describe 'Navigation Bar' do
     expect(current_path).to eq(books_path)
     click_link 'Friends'
     expect(current_path).to eq(user_friends_path)
-    click_link 'My Books'
+    click_link 'Profile'
     expect(current_path).to eq(user_books_path)
-    click_link 'Account Info'
-    expect(current_path).to eq(user_account_path)
+    # click_link 'Account Info'
+    # expect(current_path).to eq(user_account_path)
     click_link 'Home'
+    expect(current_path).to eq(root_path)
+    within 'nav' do
+      click_link 'Logout'
+    end
     expect(current_path).to eq(root_path)
   end
 end

--- a/spec/features/navigation/nav_bar_spec.rb
+++ b/spec/features/navigation/nav_bar_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'Navigation Bar' do
   end
   it 'has the correct content' do
     within 'nav' do
-      expect(page).to have_link('Home', href: root_path)
+      expect(page).to have_link('ShelfShare', href: root_path)
       expect(page).to have_link('Dashboard', href: user_dashboard_path)
-      expect(page).to have_link('Browse Books', href: books_path)
+      expect(page).to have_link('Books', href: books_path)
       expect(page).to have_link('Friends', href: user_friends_path)
       expect(page).to have_link('Profile', href: user_books_path)
       # expect(page).to have_link('Account Info', href: user_account_path)
@@ -24,7 +24,7 @@ RSpec.describe 'Navigation Bar' do
   it 'has working paths for all links' do
     click_link 'Dashboard'
     expect(current_path).to eq(user_dashboard_path)
-    click_link 'Browse Books'
+    click_link 'Books'
     expect(current_path).to eq(books_path)
     click_link 'Friends'
     expect(current_path).to eq(user_friends_path)
@@ -32,7 +32,7 @@ RSpec.describe 'Navigation Bar' do
     expect(current_path).to eq(user_books_path)
     # click_link 'Account Info'
     # expect(current_path).to eq(user_account_path)
-    click_link 'Home'
+    click_link 'ShelfShare'
     expect(current_path).to eq(root_path)
     within 'nav' do
       click_link 'Logout'

--- a/spec/features/user/dashboard_scaffold_spec.rb
+++ b/spec/features/user/dashboard_scaffold_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "Dashboard Page Scaffold" do
     expect(page).to have_css(".borrowed-books")
     expect(page).to have_css(".loaned-books")
     expect(page).to have_css(".friend-requests")
-    expect(page).to have_css(".recommendations")
     expect(page).to have_css(".in-transit")
   end
 end

--- a/spec/features/user/dashboard_spec.rb
+++ b/spec/features/user/dashboard_spec.rb
@@ -2,22 +2,26 @@ require 'rails_helper'
 
 RSpec.describe 'As a registered user' do
   describe 'When I visit my dashboard' do
-    before :each do
-      @user = User.create!(first_name: 'Neal', last_name: 'Stephenson')
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
-      @user2 = User.create!(first_name: 'John', last_name: 'Scalzi')
-      @user3 = User.create!(first_name: 'Robert', last_name: 'Heinlein')
-      @user.friend_requests.create!(from: @user2.id)
+    it 'I see a section telling me about any new friend requests' do
+      user = create(:user)
 
-      @ub1 = UserBook.create({
-        user_id: @user.id,
-        book_id: create(:book).id,
-        status: "available"
-      })
+      create_list(:friend, 5).each do |friend|
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(friend)
+        visit user_friends_path
+        fill_in :email, with: user.email
+        click_on 'Add Friend'
+      end
 
-      visit user_dashboard_path # Is this the correct route? Double check.
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit user_dashboard_path
+      within ".friend-requests" do
+        expect(page).to have_content("You have 5 new friend requests")
+      end
     end
+
+    # before :each do
+    # end
 
     xit 'I see a section listing current requests for my books, or a message if no books are being requested' do
       within ".current-requests" do
@@ -47,14 +51,6 @@ RSpec.describe 'As a registered user' do
         expect(page).to have_content("You have #{@user.lent_books} books lent out") # Create a lent_books method?
         expect(page).to have_content("Books: #{@user.lent_book_titles}")
         expect(page).to have_content("Lent To: #{@user.lent_book_to}")
-      end
-    end
-
-    xit 'I see a section telling me about any new friend requests' do
-      within ".friend-requests" do
-
-        count = @user.friend_requests.count
-        expect(page).to have_content("#{count} New Friend Requests")
       end
     end
 

--- a/spec/features/user/dashboard_spec.rb
+++ b/spec/features/user/dashboard_spec.rb
@@ -17,24 +17,27 @@ RSpec.describe 'As a registered user' do
       visit user_dashboard_path
       within ".friend-requests" do
         expect(page).to have_content("You have 5 new friend requests")
+        expect(page).to have_link("5 new friend requests", href: user_friends_path)
       end
     end
 
-    # before :each do
-    # end
+    it 'I see a section listing current requests for my books, or a message if no books are being requested' do
+      user1, user2 = create_list(:user, 2)
+      user1.friends << user2
+      user2.friends << user1
+      book = create(:book)
+      user_book1 = create(:user_book, user: user2, book: book)
+      user_book2 = create(:user_book, user: user2, book: book, status: 'unavailable')
+      borrow_request1 = create(:borrow_request, borrower: user1, user_book: user_book1)
+      borrow_request2 = create(:borrow_request, borrower: user1, user_book: user_book2, status: 1)
+      # user1 wants to borrow from user2
 
-    xit 'I see a section listing current requests for my books, or a message if no books are being requested' do
-      within ".current-requests" do
-        expect(page).to have_content("No current requests")
-      end
-
-      # Request a book here
-
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user2)
       visit user_dashboard_path
-
-      within ".current-requests" do
-        expect(page).to have_content("You have #{@user.current_book_requests} book requests") # Create a requests method that counts the number of requests?
-        expect(page).to have_content("Books: #{@user.requested_book_titles}") # Do we want the book title to show up as well? How do we grab this information?
+      within ".book-requests" do
+        expect(page).to have_content("You have 1 new book request")
+        expect(page).to have_link("1 new book request", href: borrow_index_path)
+        expect(page).to_not have_content("No current requests")
       end
     end
 

--- a/spec/features/welcome/address_new_spec.rb
+++ b/spec/features/welcome/address_new_spec.rb
@@ -2,25 +2,17 @@
 
 require 'rails_helper'
 
-RSpec.feature 'As a user' do
+RSpec.feature 'As a user who did not add an address yet' do
   before :each do
     login_as_user
-    @address = {
-      address_first: '1984 Shelf Space',
-      address_second: 'Unit 451',
-      city: 'Castle Rock',
-      state: 'ME',
-      zip: '14101'
-    }
+    @address = build(:address)
   end
 
-  scenario 'After logging in for the first time, there is a button on the welcome page to take me to the address entry form page' do
-    expect(page).to have_button('Add Address')
-  end
-
-  scenario 'Clicking on the button sends me to a form to provide my address' do
-    click_button 'Add Address'
+  scenario 'My Shipping Information will tell me to add an address if I do not have one' do
+    visit user_books_path
+    click_link 'My Shipping Information'
     expect(current_path).to eq('/addresses/new')
+    expect(page).to have_content("You haven't added an address yet. Please fill out the form below.")
 
     fill_in :address_first, with: @address[:address_first]
     fill_in :address_second, with: @address[:address_second]
@@ -35,8 +27,10 @@ RSpec.feature 'As a user' do
   end
 
   scenario 'Submitting an incomplete form redirects me to the form page with a flash message indicating the error. All fields are pre-populated with what was initially submitted' do
-    click_button 'Add Address'
+    visit user_books_path
+    click_link 'My Shipping Information'
     expect(current_path).to eq('/addresses/new')
+    expect(page).to have_content("You haven't added an address yet. Please fill out the form below.")
 
     fill_in :address_first, with: @address[:address_first]
     fill_in :address_second, with: @address[:address_second]
@@ -52,5 +46,13 @@ RSpec.feature 'As a user' do
     expect(page).to have_field(:address_second, with: @address[:address_second])
     expect(page).to have_field(:state, with: @address[:state])
     expect(page).to have_field(:zip, with: @address[:zip])
+  end
+
+  scenario 'My Shipping Information lets me view and edit my already added address' do
+    address = create :address, user: current_user
+
+    visit user_books_path
+    click_link 'My Shipping Information'
+    expect(current_path).to eq(user_account_path)
   end
 end

--- a/spec/features/welcome/prompt_for_address_after_login_spec.rb
+++ b/spec/features/welcome/prompt_for_address_after_login_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Address Prompt Page Spec" do
               "ShelfShare is a platform for sharing books via mail. " +
               "You can borrow and lend books with your friends! " +
               "To participate fully in the shipping process, we kindly ask for your address. " +
-              "Your address will be shown to other users when only when it is necessary to ship a book. " +
+              "Your address will be shown to other users only when it is necessary to ship a book. " +
               "You can edit or delete your address at any time by visiting your profile."
 
     @disclaimer = "DISCLAIMER: " +
@@ -46,7 +46,6 @@ RSpec.describe "Address Prompt Page Spec" do
     expect(current_path).to eq(user_dashboard_path)
     expect(page).to have_content('Address successfully saved')
 
-    visit root_path
     click_link "Logout"
     click_link 'Sign in with Google'
 

--- a/spec/models/borrow_request_spec.rb
+++ b/spec/models/borrow_request_spec.rb
@@ -60,4 +60,19 @@ RSpec.describe BorrowRequest do
       expect(@borrow_request.status_changed_to_returned).to eq(@borrow_request.status = 3)
     end
   end
+
+  describe '#instance methods' do
+    it "#approve_request" do
+      request = create(:request)
+      user_book = request.user_book
+
+      expect(request.status).to eq('pending')
+      expect(user_book.status).to eq('available')
+
+      request.approve_request
+
+      expect(request.status).to eq('accepted')
+      expect(user_book.status).to eq('unavailable')
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,11 +99,10 @@ RSpec.describe User, type: :model do
       @user_book1 = create(:user_book, user: @user2, book: @book)
       @user_book2 = create(:user_book, user: @user2, book: @book, status: 'unavailable')
       @borrow_request1 = create(:borrow_request, borrower: @user1, user_book: @user_book1)
-      @borrow_request2 = create(:borrow_request, borrower: @user1, user_book: @user_book1, status: 1)
+      @borrow_request2 = create(:borrow_request, borrower: @user1, user_book: @user_book2, status: 2)
       # user1 is asking for a book from user2
     end
     it 'incoming_book_borrow_requests' do
-
       expect(@user2.incoming_book_borrow_requests).to include(@borrow_request1)
       expect(@user2.incoming_book_borrow_requests).to_not include(@borrow_request2)
     end


### PR DESCRIPTION
# Description

This PR has big changes.

## New onboarding address workflow 

New users will be prompted to add an address immediately after logging in.
A user with an address will not see this notice when they already have an address.
Additionally: logging in now redirects the user to their dashboard if they already added their address.
There is a partial to re-use the form on the prompt page and the new_address page
One controller action will now handle both form inputs and also their sad paths
Address information can be updated from the profile page (aka the user books index)

##  New navbar

It's to the left of the page now!
My Books is now Profile
There is no longer an Account Info Link
The Logout button has been moved from the Welcome Page into the navbar
The navbar will say who is currently logged in
There is now a skip to content link
Browse Books is now called Books
Home is now called ShelfShare

## Dashboard notifications

The dashboard now displays simple counter notifications about friend and book requests
There are so many tests to cover this happening in different scenarios (they all use FactoryBot)
Pending requests will include a link to that resource's index page (friends index, book request index)
The requests can be dealt with on those index pages instead of the dashboard

## Updating Book request status

There are new specs regarding the book request index and accepting / declining requests.
`borrow_requests_index_spec` covers the scenarios of just seeing those requests and their buttons.
`lender_request_spec` has been completely re-written and includes integration tests to cover approving and declining book requests. 
Both of these specs test the dashboard and the borrow requests index page and they all pass.
There is a brand new approach to our issue last time of not seeing an address page:
Approving a request will redirect to an actual address show page (brand new resource)

# Removed: Users can create new book requests 

## Update: this is done, works and confirmed in browser testing.

Big heading here because I removed the functionality of the 'Ask to Borrow' button.
The previous implementation worked but didn't play nicely with how we were at the time handling status changes.
That's sugar coating it -- it just didn't work. Even when pending requests were created, we got none of that data showing anywhere it needed to be.
Now that there is brand new status change routine that has been tested through multiple scenarios... I think it's worth just trying to re-implement this feature again. As of now, devs are able to create borrow_requests in `rails c` or just in `test`.
Users cannot create new book requests at all. I believe that this will be the last step in addressing the bug (or at least the next step to a working solution.)

# Closes issue(s)

closes #60 

# How to test / reproduce

# Screenshots

# Changes include
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code

# Other comments