### PR TITLE
Address Line 1 view page

### DIFF
--- a/app/views/addresses/edit.html.erb
+++ b/app/views/addresses/edit.html.erb
@@ -1,11 +1,12 @@
 <h3><%= current_user.first_name %> <%= current_user.last_name %></h3>
 <h4>Address</h4>
 
+
 <%= form_tag( {:action => 'update'}, {method: :patch}) do %>
-  <%= label_tag :address_first, 'Address: *' %>
+  <%= label_tag :address_first, 'Address Line 1: *' %>
   <%= text_field_tag :address_first, "#{@address.address_first}"%><br>
 
-  <%= label_tag :address_second, 'Address: ' %>
+  <%= label_tag :address_second, 'Address Line 2: ' %>
   <%= text_field_tag :address_second, "#{@address.address_second}" %><br>
 
   <%= label_tag :city, 'City: *' %>
@@ -20,3 +21,5 @@
   <%= submit_tag 'Submit Address' %>
 <% end %>
 <p>*Required Field</p>
+
+<%= render 'partials/address_disclaimer' %>

--- a/app/views/partials/_new_address_form.html.erb
+++ b/app/views/partials/_new_address_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag addresses_path do %>
-  <%= label_tag :address_first, 'Address: *' %>
+  <%= label_tag :address_first, 'Address Line 1: *' %>
   <%= text_field_tag :address_first, "#{@address.address_first}"%><br>
 
-  <%= label_tag :address_second, 'Address: ' %>
+  <%= label_tag :address_second, 'Address Line 2: ' %>
   <%= text_field_tag :address_second, "#{@address.address_second}" %><br>
 
   <%= label_tag :city, 'City: *' %>

--- a/spec/features/books/search_spec.rb
+++ b/spec/features/books/search_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Find books search feature' do
 
   describe 'As a registered user' do
     it 'When I visit the find books page, I see a keyword search box' do
-      # save_and_open_page
       within ".search-books" do
         expect(page.has_field? :search).to be_truthy
       end

--- a/spec/features/user/account_show_spec.rb
+++ b/spec/features/user/account_show_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe 'Account Info Page' do
     fill_in :city, with: updated[:city]
     fill_in :state, with: updated[:state]
     fill_in :zip, with: updated[:zip]
-
+    save_and_open_page
+    expect(page).to have_content("Address Line 1")
     click_on 'Submit'
 
     expect(current_path).to eq(user_account_path)

--- a/spec/features/user/account_show_spec.rb
+++ b/spec/features/user/account_show_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe 'Account Info Page' do
     fill_in :city, with: updated[:city]
     fill_in :state, with: updated[:state]
     fill_in :zip, with: updated[:zip]
-    save_and_open_page
     expect(page).to have_content("Address Line 1")
     click_on 'Submit'
 


### PR DESCRIPTION
# Description
Address is made more clear by reading:
Address Line 1: 
Address Line 2: 

instead of:
Address 1:
Address 2:

Partial is NOT incorporated on the edit form page, since the specified action and method in the form_tag is different from the new address form.

# Closes issue(s)

# How to test / reproduce

# Screenshots

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x ] I have tested this code
- [ ] I have updated the Readme

# Other comments
