### PR TITLE
Add ad-copy to welcome page

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -3,3 +3,25 @@
 <% unless current_user %>
   <%= link_to "Sign in with Google", "/auth/google_oauth2" %>
 <% end %>
+
+<section class="about">
+  <p>
+    ShelfShare wants to help you save money by allowing you to borrow and
+    lend out books you own to your friends. We put those dusty books in
+    your collection to use!</p>
+
+    <h3>Here's why:</h3>
+
+  <ul>
+    <li>Most of us are guilty of buying that book we "have to have" just to read
+       it once and stash it on a shelf somewhere.</li><br/>
+
+    <li>Save money! Shelf share is a free service. Once you find a book you are
+      interested in on a friend's shelf, request to borrow the book, pay for
+      shipping, and you are ready to go!</li><br/>
+
+    <li>Convenience. ShelfShare is simplistic in design, no walking around the
+      library trying to find a book. Simply look through the books that your
+      friends own and request a book! Easy! 😄</li><br/>
+  </ul>
+</section>


### PR DESCRIPTION
Co-Authored-By: Jonathan Wilson <Jonathan-M-Wilson@users.noreply.github.com>

# Description
Adds some of the ad copy written for the README to the welcome page telling users why they should use the app

# Closes issue(s)
Closes #3 


# How to test / reproduce

# Screenshots
<img width="221" alt="Screen Shot 2020-09-17 at 10 30 52 PM" src="https://user-images.githubusercontent.com/62966813/93556215-73d2d000-f935-11ea-8a15-6adaf4a8d383.png">

# Changes include
- [X] New feature (non-breaking change that adds functionality)

# Checklist
- [X] I have tested this code


# Other comments
