### PR TITLE
Bug Fix: No hashes to view page

### DIFF
--- a/app/controllers/user/dashboard_controller.rb
+++ b/app/controllers/user/dashboard_controller.rb
@@ -1,7 +1,9 @@
 class User::DashboardController < ApplicationController
   def show
-    @friend_requests = current_user.current_friend_requests
+    # @friend_requests = current_user.current_friend_requests
+    @friend_requests = BorrowRequestFacade.find_current_friend_requests(current_user)
     @book_requests = BorrowRequestFacade.incoming_book_borrow_requests(current_user)
+
     @borrowed_books = current_user.borrow_requests.find_approved_requests
     @loaned_books = current_user.loaned_books
   end

--- a/app/controllers/user/friends_controller.rb
+++ b/app/controllers/user/friends_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class User::FriendsController < ApplicationController
-  def index; end
+  def index
+    @friend_requests = BorrowRequestFacade.find_current_friend_requests(current_user)
+  end
 
   def show
     @friend = User.find(params[:id])

--- a/app/facades/borrow_request_facade.rb
+++ b/app/facades/borrow_request_facade.rb
@@ -11,6 +11,16 @@ class BorrowRequestFacade
     end
   end
 
+  def self.find_current_friend_requests(current_user)
+    requests = current_user.current_friend_requests
+    requests.map do |request, friend|
+      OpenStruct.new(
+        request: request,
+        friend: friend
+      )
+    end
+  end
+
   def self.convert_to_poro(borrow_request)
     params = {
       id: borrow_request.id,

--- a/app/views/user/friends/index.html.erb
+++ b/app/views/user/friends/index.html.erb
@@ -23,10 +23,12 @@
   <% if current_user.current_friend_requests.empty? %>
     <p>No friend requests<p>
   <% else %>
-    <% current_user.current_friend_requests.each do |request, friend| %>
-      <p><%= "#{friend.first_name} wants to be your friend" %></p>
-      <%= link_to "Accept", user_friend_request_path(request.id), method: :patch %>
-      <%= link_to "Decline", user_friend_request_path(request.id), method: :delete %>
+
+
+      <% @friend_requests.each do |friend_request| %>
+        <p><%= "#{friend_request.friend.first_name} wants to be your friend" %></p>
+        <%= link_to "Accept", user_friend_request_path(friend_request.request.id), method: :patch %>
+        <%= link_to "Decline", user_friend_request_path(friend_request.request.id), method: :delete %>
     <% end %>
   <% end %>
 </section>

--- a/spec/features/friends/index_spec.rb
+++ b/spec/features/friends/index_spec.rb
@@ -37,8 +37,3 @@ RSpec.describe 'User Friends Index Page' do
     expect(page).to have_content('Add friends')
   end
 end
-
-# Future user stories:
-# I see any new friend requests with buttons to accept or decline
-# I see the book covers I am lending displayed by the friend who has them
-# I see the book covers of books I am borrowing by the friends who own them


### PR DESCRIPTION
# Description
User instance method creates a hash that is sent to the view page. This fix creates a new BorrowFacade class method to turn the hash into an OpenStruct object, which is then sent to the view page.
# Closes issue(s)

# How to test / reproduce

# Screenshots

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

# Other comments
