### PR TITLE
User book index covers lw

### DIFF
--- a/app/views/user/books/index.html.erb
+++ b/app/views/user/books/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= link_to "My Shipping Information", current_user.address.nil? ? new_address_path : user_account_path %>
 
-<section class="available-books">
+<section class='available'
 <h5>On The Shelf</h5>
 <% if @available_books.present?  %>
   <% @available_books.each do |book| %>
@@ -16,15 +16,15 @@
 <% end %>
 </section>
 
-<section class="unavailable-books">
-  <h5>Off The Shelf</h5>
-  <% if @unavailable_books.present?  %>
-    <% @unavailable_books.each do |book| %>
-      <div class="unavailable_book" id="book-<%= book.id %>">
-      <%= link_to(image_tag(book.thumbnail, alt: "#{book.title} cover image"), user_book_path(book)) %>
-    </div>
-    <% end %>
-  <% else %>
-    <p>No books are currently unavailable</p>
+<section class="unavailable">
+<h5>Off The Shelf</h5>
+<% if @unavailable_books.present?  %>
+  <% @unavailable_books.each do |book| %>
+    <div class="unavailable_book" id="book-<%= book.id %>">
+    <%= link_to(image_tag(book.thumbnail, alt: "#{book.title} cover image"), user_book_path(book)) %>
+  </div>
   <% end %>
+<% else %>
+  <p>No books are currently unavailable</p>
+<% end %>
 </section>

--- a/app/views/user/books/index.html.erb
+++ b/app/views/user/books/index.html.erb
@@ -7,7 +7,9 @@
 <h5>On The Shelf</h5>
 <% if @available_books.present?  %>
   <% @available_books.each do |book| %>
-    <%= link_to book.title, user_book_path(book) %>
+    <div class="available_book" id="book-<%= book.id %>">
+    <%= link_to(image_tag(book.thumbnail, alt: "#{book.title} cover image"), user_book_path(book)) %>
+    </div>
   <% end %>
 <% else %>
   <p>No books are currently available</p>
@@ -18,7 +20,9 @@
   <h5>Off The Shelf</h5>
   <% if @unavailable_books.present?  %>
     <% @unavailable_books.each do |book| %>
-      <%= link_to book.title, user_book_path(book) %>
+      <div class="unavailable_book" id="book-<%= book.id %>">
+      <%= link_to(image_tag(book.thumbnail, alt: "#{book.title} cover image"), user_book_path(book)) %>
+    </div>
     <% end %>
   <% else %>
     <p>No books are currently unavailable</p>

--- a/spec/features/books/friend_book_show_spec.rb
+++ b/spec/features/books/friend_book_show_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Friend Book Show Page Spec' do
 
   it "I can visit my book show page for an available book in my shelf" do
     visit user_books_path
-
     click_link @available_book.title
     expect(current_path).to eq(user_book_path(@available_book))
   end
@@ -32,7 +31,6 @@ RSpec.describe 'Friend Book Show Page Spec' do
 
   it "I can visit my book show page for an UNavailable book in my shelf" do
     visit user_books_path
-
     click_link @unavailable_book.title
     expect(current_path).to eq(user_book_path(@unavailable_book))
   end
@@ -61,20 +59,25 @@ RSpec.describe 'Friend Book Show Page Spec' do
     visit user_book_path(@available_book)
     expect(page).to have_content(@available_book.title)
     click_button 'Change Status'
+    @available_book.reload
+    @available_book.user_books[0].reload
 
     expect(current_path).to eq(user_books_path)
-    expect(page).to have_content("Status changed for #{@available_book.title}")
 
-    within('.unavailable-books') do
-      expect(page).to have_content(@available_book.title)
+    expect(page).to have_content("Status changed for #{@available_book.title}")
+    visit current_path
+
+    expect(page).to have_css('.unavailable_book')
+    within('.unavailable') do
+      expect(page).to have_css("img[src*='#{@available_book.thumbnail}']")
     end
     visit user_book_path(@available_book)
     click_button 'Change Status'
 
     expect(current_path).to eq(user_books_path)
     expect(page).to have_content("Status changed for #{@available_book.title}")
-    within('.available-books') do
-      expect(page).to have_content(@available_book.title)
+    within('.available') do
+      expect(page).to have_css("img[src*='#{@available_book.thumbnail}']")
     end
   end
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'User Book Index Page' do
     login_as_user
     @book1 = create(:book)
     @book2 = create(:book)
+    # @book1.user_booka.create(user_id: current_user.id, status: 'available')
+    # @book2.userbook.create(user_id: current_user.id, status: 'available')
   end
 
   it 'My books show up on the shelf' do
@@ -21,10 +23,12 @@ RSpec.describe 'User Book Index Page' do
                       status: 'unavailable'
                     })
     visit user_books_path
-    expect(page).to have_content(@book1.title)
-    expect(page).to have_content(@book2.title)
+    expect(page).to have_css("img[src*='#{@book1.thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book2.thumbnail}']")
     expect(page).to have_content("On The Shelf")
     expect(page).to have_content("Off The Shelf")
+    expect(page).to have_css(".available_book", count: 1)
+    expect(page).to have_css(".unavailable_book", count: 1)
   end
 
   it 'If I have no available books, the page will indicate it' do
@@ -39,11 +43,10 @@ RSpec.describe 'User Book Index Page' do
                       status: 'unavailable'
                     })
     visit user_books_path
-    expect(page).to have_content(@book1.title)
-    expect(page).to have_content(@book2.title)
-    expect(page).to have_content("On The Shelf")
-    expect(page).to have_content("Off The Shelf")
+    expect(page).to have_css("img[src*='#{@book1.thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book2.thumbnail}']")
     expect(page).to have_content("No books are currently available")
+    expect(page).to have_css(".unavailable_book", count: 2)
   end
 
   it 'If I have no unavailable books, the page will indicate it' do
@@ -58,11 +61,26 @@ RSpec.describe 'User Book Index Page' do
                       status: 'available'
                     })
     visit user_books_path
-    expect(page).to have_content(@book1.title)
-    expect(page).to have_content(@book2.title)
-    expect(page).to have_content("On The Shelf")
-    expect(page).to have_content("Off The Shelf")
+    expect(page).to have_css("img[src*='#{@book1.thumbnail}']")
+    expect(page).to have_css("img[src*='#{@book2.thumbnail}']")
     expect(page).to have_content("No books are currently unavailable")
-    save_and_open_page
+  end
+
+  it "The book cover is a link that takes me to the user book show page" do
+    UserBook.create({
+                      user_id: current_user.id,
+                      book_id: @book1.id,
+                      status: 'available'
+                    })
+    UserBook.create({
+                      user_id: current_user.id,
+                      book_id: @book2.id,
+                      status: 'unavailable'
+                    })
+    visit user_books_path
+    within('.available_book') do
+      find(:xpath, "//a[contains(@href,#{@book1.id})]").click
+    end
+    expect(current_path).to eq(user_book_path(@book1))
   end
 end

--- a/spec/features/books/user_books_index_spec.rb
+++ b/spec/features/books/user_books_index_spec.rb
@@ -63,5 +63,6 @@ RSpec.describe 'User Book Index Page' do
     expect(page).to have_content("On The Shelf")
     expect(page).to have_content("Off The Shelf")
     expect(page).to have_content("No books are currently unavailable")
+    save_and_open_page
   end
 end


### PR DESCRIPTION
# Description
Change User book index page to show book covers instead of titles.
This creates consistency with the rest of the book index pages/shelves..
The covers are links to the book show page.
# Closes issue(s)

# How to test / reproduce

# Screenshots

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

# Other comments
